### PR TITLE
子FragmentのMenuが残り続ける問題を解決した

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/view/search/SearchTopFragment.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/view/search/SearchTopFragment.kt
@@ -31,8 +31,7 @@ class SearchTopFragment : Fragment(){
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val activity = activity ?: return
-        search_view_pager.adapter = SearchPagerAdapter(activity.supportFragmentManager, requireContext())
+        search_view_pager.adapter = SearchPagerAdapter(this.childFragmentManager, requireContext())
         search_tab_layout.setupWithViewPager(search_view_pager)
     }
 


### PR DESCRIPTION
activity.supportFragmentManagerをFragmentから呼び出しているのが原因だった
（そりゃ必要なイベントが伝播しないわけだ）