### PR TITLE
Fix/note event bug

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/MiApplication.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/MiApplication.kt
@@ -238,7 +238,7 @@ class MiApplication : Application(), MiCore {
         )
         mSocketConnectionQueue = SocketConnectionQueue(mSocketWithAccountProvider, applicationScope, Dispatchers.IO, loggerFactory)
 
-        mNoteCaptureAPIWithAccountProvider = NoteCaptureAPIWithAccountProvider(mSocketWithAccountProvider, loggerFactory)
+        mNoteCaptureAPIWithAccountProvider = NoteCaptureAPIWithAccountProviderImpl(mSocketWithAccountProvider, loggerFactory)
 
         mNoteCaptureAPIAdapter = NoteCaptureAPIAdapter(
             mAccountRepository,

--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/NoteCaptureAPIWithAccountProvider.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/NoteCaptureAPIWithAccountProvider.kt
@@ -9,18 +9,21 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
+interface NoteCaptureAPIWithAccountProvider {
+    fun get(account: Account): NoteCaptureAPI
+}
 /**
  * NoteCaptureAPIのインスタンスをAccountに基づきいい感じに取得や生成をできるようにする。
  */
-class NoteCaptureAPIWithAccountProvider(
+class NoteCaptureAPIWithAccountProviderImpl(
     private val socketWithAccountProvider: SocketWithAccountProvider,
     private val loggerFactory: Logger.Factory? = null
-) {
+) : NoteCaptureAPIWithAccountProvider{
 
     private val accountIdWithNoteCaptureAPI = mutableMapOf<Long, NoteCaptureAPI>()
     private val lock = Mutex()
 
-    fun get(account: Account) : NoteCaptureAPI = runBlocking{
+    override fun get(account: Account) : NoteCaptureAPI = runBlocking{
         lock.withLock {
             var channelAPI = accountIdWithNoteCaptureAPI[account.accountId]
             if(channelAPI != null) {

--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/NoteCaptureAPIWithAccountProvider.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/NoteCaptureAPIWithAccountProvider.kt
@@ -4,6 +4,7 @@ import jp.panta.misskeyandroidclient.Logger
 import jp.panta.misskeyandroidclient.model.account.Account
 import jp.panta.misskeyandroidclient.streaming.SocketWithAccountProvider
 import jp.panta.misskeyandroidclient.streaming.notes.NoteCaptureAPI
+import jp.panta.misskeyandroidclient.streaming.notes.NoteCaptureAPIImpl
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -27,7 +28,7 @@ class NoteCaptureAPIWithAccountProvider(
             }
 
             val socket = socketWithAccountProvider.get(account)
-            channelAPI = NoteCaptureAPI(socket, loggerFactory)
+            channelAPI = NoteCaptureAPIImpl(socket, loggerFactory)
             accountIdWithNoteCaptureAPI[account.accountId] = channelAPI
 
             return@runBlocking channelAPI

--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/impl/InMemoryNoteDataSource.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/impl/InMemoryNoteDataSource.kt
@@ -96,7 +96,7 @@ class InMemoryNoteDataSource(
     private suspend fun createOrUpdate(note: Note): AddResult {
         mutex.withLock{
             val n = this.notes[note.id]
-            if(n != null && n.instanceUpdatedAt != note.instanceUpdatedAt){
+            if(n != null && n.instanceUpdatedAt > note.instanceUpdatedAt){
                 return AddResult.CANCEL
             }
             this.notes[note.id] = note

--- a/app/src/test/java/jp/panta/misskeyandroidclient/model/notes/impl/InMemoryNoteDataSourceTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/model/notes/impl/InMemoryNoteDataSourceTest.kt
@@ -1,5 +1,6 @@
 package jp.panta.misskeyandroidclient.model.notes.impl
 
+import jp.panta.misskeyandroidclient.Logger
 import jp.panta.misskeyandroidclient.api.notes.NoteDTO
 import jp.panta.misskeyandroidclient.api.notes.toNote
 import jp.panta.misskeyandroidclient.api.users.UserDTO
@@ -8,17 +9,23 @@ import jp.panta.misskeyandroidclient.model.AddResult
 import jp.panta.misskeyandroidclient.model.account.Account
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.*
+import org.junit.Before
 import org.junit.Test
 import java.util.*
 
 class InMemoryNoteDataSourceTest {
 
+    lateinit var loggerFactory: Logger.Factory
+    lateinit var account: Account
+    @Before
+    fun setUp() {
+        loggerFactory = TestLogger.Factory()
+        account = Account(remoteId = "piyo", instanceDomain = "", encryptedToken = "", userName = "piyoName")
+    }
     @Test
     fun testAdd() {
-        val loggerFactory = TestLogger.Factory()
-        val noteRepository = InMemoryNoteDataSource(loggerFactory)
+        val noteDataSource = InMemoryNoteDataSource(loggerFactory)
 
-        val account = Account(remoteId = "piyo", instanceDomain = "", encryptedToken = "", userName = "piyoName")
         val dto = NoteDTO(
             "",
             Date(),
@@ -29,19 +36,43 @@ class InMemoryNoteDataSourceTest {
         )
         val note = dto.toNote(account)
         runBlocking {
-            val result = noteRepository.add(
+            val result = noteDataSource.add(
                 note
             )
 
             assertTrue(result == AddResult.CREATED)
             val old = note.copy()
 
-            assertTrue(noteRepository.add(note) == AddResult.UPDATED)
+            assertTrue(noteDataSource.add(note) == AddResult.UPDATED)
 
-            assertTrue(noteRepository.add(old) == AddResult.CANCEL)
+            assertTrue(noteDataSource.add(old) == AddResult.CANCEL)
 
-            assertTrue(noteRepository.add(old.copy()) == AddResult.CANCEL)
+            assertTrue(noteDataSource.add(old.copy()) == AddResult.CANCEL)
         }
 
+    }
+
+
+    @Test
+    fun testUpdateNote(): Unit = runBlocking{
+        val noteDataSource = InMemoryNoteDataSource(loggerFactory)
+
+        val dto = NoteDTO(
+            "note-1",
+            Date(),
+            renoteCount = 0,
+            replyCount = 0,
+            userId = "hoge",
+            user = UserDTO("hoge", "hogeName")
+        )
+        val note = dto.toNote(account)
+        noteDataSource.add(
+            note
+        )
+
+        val dtoParsed = dto.toNote(account)
+        assertEquals(AddResult.UPDATED, noteDataSource.add(dtoParsed))
+
+        assertTrue(dtoParsed === noteDataSource.get(dtoParsed.id))
     }
 }


### PR DESCRIPTION
InMemoryNoteDataSourceの更新条件が新旧の最新更新日時が一致しなければ更新されない仕組みになっていたので
追加されるデータのインスタンスの最終更新日時がすでにあるインスタンスの更新日時より新しければ更新するようにした。
