### PR TITLE
投稿に失敗した理由を表示するようにした

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/MainActivityEventHandler.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/MainActivityEventHandler.kt
@@ -34,6 +34,7 @@ import net.pantasystem.milktea.notification.notificationMessageScope
 import net.pantasystem.milktea.user.ReportStateHandler
 import net.pantasystem.milktea.worker.note.CreateNoteWorkerExecutor
 
+@Suppress("DEPRECATION")
 internal class MainActivityEventHandler(
     val activity: MainActivity,
     val binding: ActivityMainBinding,
@@ -257,7 +258,7 @@ internal class MainActivityEventHandler(
     }
 
     private fun showCreateNoteTaskStatusSnackBar(state: WorkInfo) {
-        ShowNoteCreationResultSnackBar(
+        NoteCreateResultHandler(
             activity,
             binding.appBarMain.simpleNotification,
             createNoteWorkerExecutor,

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/NotePostFailedDialogFragment.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/NotePostFailedDialogFragment.kt
@@ -3,9 +3,31 @@ package jp.panta.misskeyandroidclient.ui.main
 import android.app.Dialog
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.google.android.material.composethemeadapter.MdcTheme
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import jp.panta.misskeyandroidclient.R
+import net.pantasystem.milktea.worker.note.CreateNoteWorker
 import net.pantasystem.milktea.worker.note.CreateNoteWorkerExecutor
 import javax.inject.Inject
 
@@ -14,11 +36,19 @@ class NotePostFailedDialogFragment : AppCompatDialogFragment() {
 
     companion object {
         private const val DRAFT_NOTE_ID = "DRAFT_NOTE_ID"
+        private const val ERROR_REASON_TYPE = "ERROR_REASON_TYPE"
+        private const val STACKTRACE = "STACKTRACE"
 
-        fun newInstance(draftNoteId: Long): NotePostFailedDialogFragment {
+        fun newInstance(
+            draftNoteId: Long,
+            errorReasonType: CreateNoteWorker.ErrorReasonType,
+            stackTrace: String?,
+        ): NotePostFailedDialogFragment {
             return NotePostFailedDialogFragment().apply {
                 arguments = Bundle().apply {
                     putLong(DRAFT_NOTE_ID, draftNoteId)
+                    putString(ERROR_REASON_TYPE, errorReasonType.name)
+                    putString(STACKTRACE, stackTrace)
                 }
             }
         }
@@ -31,15 +61,79 @@ class NotePostFailedDialogFragment : AppCompatDialogFragment() {
     private val draftNoteId: Long by lazy {
         requireArguments().getLong(DRAFT_NOTE_ID)
     }
+
+    private val errorReasonType: CreateNoteWorker.ErrorReasonType by lazy {
+        requireArguments().getString(ERROR_REASON_TYPE)?.let { type ->
+            CreateNoteWorker.ErrorReasonType.values().find {
+                it.name == type
+            }
+        } ?: CreateNoteWorker.ErrorReasonType.UnknownError
+    }
+
+    private val stackTrace: String? by lazy {
+        requireArguments().getString(STACKTRACE)
+    }
+
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         return MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.note_creation_failure)
             .setPositiveButton(R.string.retry){ _, _ ->
                 createNoteWorkerExecutor.enqueue(draftNoteId)
             }
+            .setView(
+                ComposeView(requireContext()).apply {
+                    setContent {
+                        MdcTheme {
+                            var isVisibleDetailMessage by remember { mutableStateOf(false) }
+                            Column(Modifier.padding(horizontal = 16.dp)) {
+                                Text(
+                                    getReasonText(
+                                        errorReasonType = errorReasonType,
+                                        stackTrace = stackTrace
+                                    ),
+                                    Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
+                                    fontWeight = FontWeight.Bold,
+                                )
+                                TextButton(onClick = { isVisibleDetailMessage = !isVisibleDetailMessage }) {
+                                    Text(stringResource(id = R.string.show_error))
+                                }
+                                AnimatedVisibility(
+                                    visible = isVisibleDetailMessage,
+                                ) {
+                                    TextField(
+                                        stackTrace ?: "Unknown Error",
+                                        onValueChange = {},
+                                        modifier = Modifier.heightIn(
+                                            min = 100.dp,
+                                            max = 300.dp
+                                        ).verticalScroll(rememberScrollState()),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            )
             .setNegativeButton(R.string.cancel) { _, _ ->
                 dismiss()
             }
             .create()
+    }
+}
+
+@Composable
+fun getReasonText(errorReasonType: CreateNoteWorker.ErrorReasonType, stackTrace: String?): String {
+    val context = LocalContext.current
+    return when(errorReasonType) {
+        CreateNoteWorker.ErrorReasonType.NetworkError -> context.getString(R.string.network_error)
+        CreateNoteWorker.ErrorReasonType.FileUploadDeviceSecurityError -> "Device File Security Error"
+        CreateNoteWorker.ErrorReasonType.FileUploadDriveNoFreeSpaceError -> context.getString(R.string.misskey_role_drive_no_free_space_error_message)
+        CreateNoteWorker.ErrorReasonType.ServerError -> context.getString(R.string.server_error)
+        CreateNoteWorker.ErrorReasonType.ClientError -> context.getString(R.string.parameter_error)
+        CreateNoteWorker.ErrorReasonType.UnauthorizedError -> context.getString(R.string.unauthorized_error)
+        CreateNoteWorker.ErrorReasonType.IAmAiError -> context.getString(R.string.bot_error)
+        CreateNoteWorker.ErrorReasonType.ToManyRequestError -> context.getString(R.string.rate_limit_error)
+        CreateNoteWorker.ErrorReasonType.NotFoundError -> context.getString(R.string.not_found_error)
+        CreateNoteWorker.ErrorReasonType.UnknownError -> stackTrace ?: "Unknown Error"
     }
 }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/NotePostFailedDialogFragment.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/NotePostFailedDialogFragment.kt
@@ -1,0 +1,45 @@
+package jp.panta.misskeyandroidclient.ui.main
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatDialogFragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import dagger.hilt.android.AndroidEntryPoint
+import jp.panta.misskeyandroidclient.R
+import net.pantasystem.milktea.worker.note.CreateNoteWorkerExecutor
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class NotePostFailedDialogFragment : AppCompatDialogFragment() {
+
+    companion object {
+        private const val DRAFT_NOTE_ID = "DRAFT_NOTE_ID"
+
+        fun newInstance(draftNoteId: Long): NotePostFailedDialogFragment {
+            return NotePostFailedDialogFragment().apply {
+                arguments = Bundle().apply {
+                    putLong(DRAFT_NOTE_ID, draftNoteId)
+                }
+            }
+        }
+    }
+
+
+    @Inject
+    internal lateinit var createNoteWorkerExecutor: CreateNoteWorkerExecutor
+
+    private val draftNoteId: Long by lazy {
+        requireArguments().getLong(DRAFT_NOTE_ID)
+    }
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.note_creation_failure)
+            .setPositiveButton(R.string.retry){ _, _ ->
+                createNoteWorkerExecutor.enqueue(draftNoteId)
+            }
+            .setNegativeButton(R.string.cancel) { _, _ ->
+                dismiss()
+            }
+            .create()
+    }
+}

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/ShowNoteCreationResultSnackBar.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/ShowNoteCreationResultSnackBar.kt
@@ -1,7 +1,7 @@
 package jp.panta.misskeyandroidclient.ui.main
 
-import android.app.Activity
 import android.view.View
+import androidx.appcompat.app.AppCompatActivity
 import androidx.work.WorkInfo
 import com.google.android.material.snackbar.Snackbar
 import jp.panta.misskeyandroidclient.R
@@ -11,7 +11,7 @@ import net.pantasystem.milktea.worker.note.CreateNoteWorker
 import net.pantasystem.milktea.worker.note.CreateNoteWorkerExecutor
 
 internal class ShowNoteCreationResultSnackBar(
-    private val activity: Activity,
+    private val activity: AppCompatActivity,
     private val view: View,
     private val createNoteWorkerExecutor: CreateNoteWorkerExecutor,
 ) {
@@ -44,11 +44,10 @@ internal class ShowNoteCreationResultSnackBar(
                     workInfo.outputData.getLong(CreateNoteWorker.EXTRA_DRAFT_NOTE_ID, -1).takeIf {
                         it != -1L
                     } ?: return
-                activity.getString(R.string.note_creation_failure).showSnackBar(
-                    activity.getString(R.string.retry) to ({
-                        createNoteWorkerExecutor.enqueue(draftNoteId)
-                    })
-                )
+                if (activity.supportFragmentManager.findFragmentByTag("NotePostFailedDialogFragment") == null) {
+                    NotePostFailedDialogFragment.newInstance(draftNoteId)
+                        .show(activity.supportFragmentManager, "NotePostFailedDialogFragment")
+                }
                 createNoteWorkerExecutor.onHandled(workInfo.id)
             }
             WorkInfo.State.BLOCKED -> Unit

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -619,6 +619,7 @@
     <string name="reaction_acceptance">リアクションの受け入れ</string>
     <string name="media_display_mode_default">デフォルト</string>
     <string name="media_display_mode_always">常にメディアを非表示</string>
+    <string name="misskey_role_drive_no_free_space_error_message">ドライブの空き容量がないため、ファイルをアップロードできません。</string>
     <!-- User -->
 
 

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -610,6 +610,7 @@
     <string name="settings_display_icons_as_squares">Display icons as squares</string>
     <string name="media_display_mode_default">Default</string>
     <string name="media_display_mode_always">Always hide</string>
+    <string name="misskey_role_drive_no_free_space_error_message">无法上传文件，因为硬盘没有可用空间</string>
     <!-- User -->
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -618,6 +618,7 @@
     <string name="reaction_acceptance_only_likes">Only likes</string>
     <string name="media_display_mode_default">Default</string>
     <string name="media_display_mode_always">Always hide media</string>
+    <string name="misskey_role_drive_no_free_space_error_message">Cannot upload the file because you have no free space of drive.</string>
     <!-- reaction-acceptance -->
 
 </resources>

--- a/modules/worker/src/main/java/net/pantasystem/milktea/worker/note/CreateNoteWorker.kt
+++ b/modules/worker/src/main/java/net/pantasystem/milktea/worker/note/CreateNoteWorker.kt
@@ -2,9 +2,15 @@ package net.pantasystem.milktea.worker.note
 
 import android.content.Context
 import androidx.hilt.work.HiltWorker
-import androidx.work.*
+import androidx.work.CoroutineWorker
+import androidx.work.OneTimeWorkRequest
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import net.pantasystem.milktea.common.APIError
+import net.pantasystem.milktea.common.ErrorType
 import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.common.mapCancellableCatching
 import net.pantasystem.milktea.model.account.AccountRepository
@@ -12,6 +18,7 @@ import net.pantasystem.milktea.model.notes.CreateNoteUseCase
 import net.pantasystem.milktea.model.notes.draft.DraftNoteRepository
 import net.pantasystem.milktea.model.notes.toCreateNote
 import net.pantasystem.milktea.worker.WorkerTags
+import java.io.IOException
 
 @HiltWorker
 class CreateNoteWorker @AssistedInject constructor(
@@ -22,10 +29,30 @@ class CreateNoteWorker @AssistedInject constructor(
     private val accountRepository: AccountRepository,
     loggerFactory: Logger.Factory
 ) : CoroutineWorker(context, params) {
+
+    enum class ErrorReasonType {
+        NetworkError,
+        FileUploadDeviceSecurityError,
+        FileUploadDriveNoFreeSpaceError,
+        ServerError,
+        ClientError,
+        UnauthorizedError,
+        IAmAiError,
+        ToManyRequestError,
+        NotFoundError,
+        UnknownError,
+    }
+
     companion object {
         const val EXTRA_DRAFT_NOTE_ID = "DRAFT_NOTE_ID"
         const val EXTRA_NOTE_ID = "NOTE_ID"
         const val EXTRA_ACCOUNT_ID = "ACCOUNT_ID"
+
+        const val EXTRA_FAILED_STACKTRACE = "FAILED_STACKTRACE"
+        const val EXTRA_FAILED_MESSAGE = "FAILED_MESSAGE"
+        const val EXTRA_FAILED_CAUSE = "FAILED_CAUSE"
+        const val EXTRA_FAILED_THROWABLE_TO_STRING = "FAILED_THROWABLE_TO_STRING"
+        const val EXTRA_FAILED_REASON = "FAILED_REASON"
 
         fun createWorker(draftNoteId: Long): OneTimeWorkRequest {
             return OneTimeWorkRequestBuilder<CreateNoteWorker>()
@@ -59,8 +86,51 @@ class CreateNoteWorker @AssistedInject constructor(
                 ))
             },
             onFailure = {
-                Result.failure(params.inputData)
+                val data = workDataOf(
+                    EXTRA_DRAFT_NOTE_ID to inputData.getLong(EXTRA_DRAFT_NOTE_ID, -1),
+                    EXTRA_FAILED_STACKTRACE to it.stackTraceToString(),
+                    EXTRA_FAILED_MESSAGE to it.message,
+                    EXTRA_FAILED_CAUSE to it.cause?.toString(),
+                    EXTRA_FAILED_THROWABLE_TO_STRING to it.toString(),
+                    EXTRA_FAILED_REASON to convertToErrorReason(it).name,
+                )
+                Result.failure(data)
             }
         )
+    }
+
+    private fun convertToErrorReason(type: Throwable): ErrorReasonType {
+        return when(type) {
+            is APIError -> {
+                when (type) {
+                    is APIError.AuthenticationException -> ErrorReasonType.UnauthorizedError
+                    is APIError.ClientException -> {
+                        when(val errorType = type.error) {
+                            is ErrorType.Misskey -> {
+                                when(errorType.error.error.code) {
+                                    "NO_FREE_SPACE" -> ErrorReasonType.FileUploadDriveNoFreeSpaceError
+                                    else -> ErrorReasonType.ClientError
+                                }
+                            }
+                            is ErrorType.Raw -> ErrorReasonType.ClientError
+                            null -> ErrorReasonType.ClientError
+                        }
+                    }
+                    is APIError.ForbiddenException -> ErrorReasonType.UnauthorizedError
+                    is APIError.IAmAIException -> ErrorReasonType.IAmAiError
+                    is APIError.InternalServerException -> ErrorReasonType.ServerError
+                    is APIError.NotFoundException -> ErrorReasonType.NotFoundError
+                    is APIError.SomethingException -> ErrorReasonType.UnknownError
+                    is APIError.ToManyRequestsException -> ErrorReasonType.ToManyRequestError
+                }
+            }
+            is SecurityException -> {
+                ErrorReasonType.FileUploadDeviceSecurityError
+            }
+            is IOException -> {
+                ErrorReasonType.NetworkError
+            }
+            else -> ErrorReasonType.UnknownError
+        }
     }
 }


### PR DESCRIPTION
## やったこと
今まで投稿に失敗した場合はSnackBarに失敗した趣旨を表示し、リトライのアクションを表示していた。
しかし何を表示したいのかよくわからないので、
ダイアログで表示するようにし、ダイアログにより詳細な内容を表示するようにした。

## 動作確認


## スクリーンショット(任意)
|エラーダイアログ表示時(通常時)|エラーダイアログ表示時(エラー詳細表示時)|
|-|-|
|<img width="429" alt="スクリーンショット 2023-08-14 21 25 24" src="https://github.com/pantasystem/Milktea/assets/38454985/1a4d322e-c161-4a60-8ca8-713ae23e7fae">|<img width="431" alt="スクリーンショット 2023-08-14 21 25 38" src="https://github.com/pantasystem/Milktea/assets/38454985/77c6d344-3d37-4d50-97a7-7348b208e58f">|


## 備考


## Issue番号
Closed #1821 


