### PR TITLE
ノートのリアクションカウンター表示にRecyclerViewを用いるのをやめた

### DIFF
--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/NoteChildConversationAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/NoteChildConversationAdapter.kt
@@ -10,7 +10,11 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.flexbox.*
+import com.google.android.flexbox.AlignItems
+import com.google.android.flexbox.FlexDirection
+import com.google.android.flexbox.FlexWrap
+import com.google.android.flexbox.FlexboxLayoutManager
+import com.google.android.flexbox.JustifyContent
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -48,7 +52,7 @@ class NoteChildConversationAdapter(
     override fun onBindViewHolder(holder: SimpleNoteHolder, position: Int) {
         holder.binding.note = getItem(position)
         holder.binding.noteCardActionListener = actionAdapter
-        setReactionCounter(getItem(position), holder.binding.reactionView)
+//        setReactionCounter(getItem(position), holder.binding.reactionView)
         holder.binding.executePendingBindings()
     }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/NoteChildConversationAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/NoteChildConversationAdapter.kt
@@ -10,11 +10,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.flexbox.AlignItems
-import com.google.android.flexbox.FlexDirection
-import com.google.android.flexbox.FlexWrap
-import com.google.android.flexbox.FlexboxLayoutManager
-import com.google.android.flexbox.JustifyContent
+import com.google.android.flexbox.FlexboxLayout
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -22,8 +18,9 @@ import net.pantasystem.milktea.model.setting.DefaultConfig
 import net.pantasystem.milktea.model.setting.LocalConfigRepository
 import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.databinding.ItemSimpleNoteBinding
-import net.pantasystem.milktea.note.reaction.ReactionCountAdapter
 import net.pantasystem.milktea.note.timeline.NoteFontSizeBinder
+import net.pantasystem.milktea.note.timeline.ReactionCountItemsFlexboxLayoutBinder
+import net.pantasystem.milktea.note.timeline.ViewRecycler
 import net.pantasystem.milktea.note.view.NoteCardAction
 import net.pantasystem.milktea.note.view.NoteCardActionListenerAdapter
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
@@ -49,10 +46,17 @@ class NoteChildConversationAdapter(
 
     private val actionAdapter = NoteCardActionListenerAdapter(onAction)
 
+    private val reactionCountBinder = ReactionCountItemsFlexboxLayoutBinder(
+        ViewRecycler()
+    ) {
+        actionAdapter.onReactionCountAction(it)
+    }
+
     override fun onBindViewHolder(holder: SimpleNoteHolder, position: Int) {
         holder.binding.note = getItem(position)
         holder.binding.noteCardActionListener = actionAdapter
-//        setReactionCounter(getItem(position), holder.binding.reactionView)
+
+        setReactionCounter(getItem(position), holder.binding.reactionView)
         holder.binding.executePendingBindings()
     }
 
@@ -68,34 +72,20 @@ class NoteChildConversationAdapter(
 
     private var job: Job? = null
 
-    private fun setReactionCounter(note: PlaneNoteViewData, reactionView: RecyclerView){
+    private fun setReactionCounter(note: PlaneNoteViewData, reactionView: FlexboxLayout){
 
         val reactionList = note.reactionCountsViewData.value
-        val adapter = ReactionCountAdapter {
-            actionAdapter.onReactionCountAction(it)
-        }
-        adapter.note = note
-        reactionView.adapter = adapter
-
-        adapter.submitList(reactionList)
 
         job?.cancel()
         job = note.reactionCountsViewData.onEach {
-            adapter.submitList(it.toList())
+            reactionCountBinder.bindReactionCounts(reactionView, note, it)
         }.flowWithLifecycle(lifecycleOwner.lifecycle).launchIn(lifecycleOwner.lifecycleScope)
 
-        val exLayoutManager = reactionView.layoutManager
-        if(exLayoutManager !is FlexboxLayoutManager){
-            val flexBoxLayoutManager = FlexboxLayoutManager(reactionView.context)
-            flexBoxLayoutManager.flexDirection = FlexDirection.ROW
-            flexBoxLayoutManager.flexWrap = FlexWrap.WRAP
-            flexBoxLayoutManager.justifyContent = JustifyContent.FLEX_START
-            flexBoxLayoutManager.alignItems = AlignItems.STRETCH
-            reactionView.layoutManager = flexBoxLayoutManager
-        }
 
         if(reactionList.isNotEmpty()){
             reactionView.visibility = View.VISIBLE
+        } else {
+            reactionView.visibility = View.GONE
         }
 
     }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/NoteDetailAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/NoteDetailAdapter.kt
@@ -12,7 +12,11 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.flexbox.*
+import com.google.android.flexbox.AlignItems
+import com.google.android.flexbox.FlexDirection
+import com.google.android.flexbox.FlexWrap
+import com.google.android.flexbox.FlexboxLayoutManager
+import com.google.android.flexbox.JustifyContent
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -144,7 +148,7 @@ class NoteDetailAdapter(
         when (holder) {
             is NoteHolder -> {
                 holder.binding.note = note
-                setReactionCounter(note, holder.binding.simpleNote.reactionView)
+//                setReactionCounter(note, holder.binding.simpleNote.reactionView)
 
                 holder.binding.lifecycleOwner = viewLifecycleOwner
                 holder.binding.noteCardActionListener = noteCardActionListenerAdapter
@@ -153,7 +157,7 @@ class NoteDetailAdapter(
             is DetailNoteHolder -> {
                 holder.binding.note = note as NoteDetailViewData
                 holder.binding.noteCardActionListener = noteCardActionListenerAdapter
-                setReactionCounter(note, holder.binding.reactionView)
+//                setReactionCounter(note, holder.binding.reactionView)
                 holder.binding.lifecycleOwner = viewLifecycleOwner
                 holder.binding.executePendingBindings()
             }
@@ -163,7 +167,7 @@ class NoteDetailAdapter(
                     "conversation: ${(note as NoteConversationViewData).conversation.value?.size}"
                 )
                 holder.binding.childrenViewData = note
-                setReactionCounter(note, holder.binding.childNote.reactionView)
+//                setReactionCounter(note, holder.binding.childNote.reactionView)
 
                 holder.binding.noteDetailViewModel = noteDetailViewModel
                 val adapter = NoteChildConversationAdapter(configRepository, viewLifecycleOwner, onAction)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/ReactionCountItemsInflater.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/ReactionCountItemsInflater.kt
@@ -2,6 +2,7 @@ package net.pantasystem.milktea.note.timeline
 
 import android.view.LayoutInflater
 import android.view.View
+import com.bumptech.glide.Glide
 import com.google.android.flexbox.FlexboxLayout
 import net.pantasystem.milktea.common_android.ui.FontSizeHelper.setMemoFontSpSize
 import net.pantasystem.milktea.note.databinding.ItemReactionBinding
@@ -26,6 +27,7 @@ class ReactionCountItemsFlexboxLayoutBinder(
 
             val child = flexboxLayout.getChildAt(flexboxLayout.childCount - 1)
             flexboxLayout.removeViewAt(flexboxLayout.childCount - 1)
+            Glide.with(child).clear(ItemReactionBinding.bind(child).reactionImage)
             viewRecycler.recycleView(child)
         }
 
@@ -115,10 +117,4 @@ class ViewRecycler<T> where T : View {
         }
     }
 
-    /**
-     * 現在リサイクル待ちのビューの数を取得する。
-     */
-    fun recycledViewCount(): Int {
-        return recycledViews.size
-    }
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/ReactionCountItemsInflater.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/ReactionCountItemsInflater.kt
@@ -1,0 +1,124 @@
+package net.pantasystem.milktea.note.timeline
+
+import android.view.LayoutInflater
+import android.view.View
+import com.google.android.flexbox.FlexboxLayout
+import net.pantasystem.milktea.common_android.ui.FontSizeHelper.setMemoFontSpSize
+import net.pantasystem.milktea.note.databinding.ItemReactionBinding
+import net.pantasystem.milktea.note.reaction.NoteReactionViewHelper.bindReactionCount
+import net.pantasystem.milktea.note.reaction.ReactionCountAction
+import net.pantasystem.milktea.note.reaction.ReactionHelper.applyBackgroundColor
+import net.pantasystem.milktea.note.reaction.ReactionViewData
+import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
+import java.util.Stack
+
+class ReactionCountItemsFlexboxLayoutBinder(
+    val viewRecycler: ViewRecycler<View>,
+    val reactionCountActionListener: (ReactionCountAction) -> Unit,
+) {
+
+    fun bindReactionCounts(flexboxLayout: FlexboxLayout, currentNote: PlaneNoteViewData?, reactionCounts: List<ReactionViewData>) {
+        val currentViewsCount = flexboxLayout.childCount
+        val newDataCount = reactionCounts.size
+
+        // Step 1: Remove unnecessary views
+        while (flexboxLayout.childCount > newDataCount) {
+
+            val child = flexboxLayout.getChildAt(flexboxLayout.childCount - 1)
+            flexboxLayout.removeViewAt(flexboxLayout.childCount - 1)
+            viewRecycler.recycleView(child)
+        }
+
+        reactionCounts.forEachIndexed { index, reactionData ->
+            val existingBinding: ItemReactionBinding? = if (index < currentViewsCount) {
+                ItemReactionBinding.bind(flexboxLayout.getChildAt(index))
+            } else null
+
+            val binding = existingBinding ?: viewRecycler.getRecycledView {
+                ItemReactionBinding.inflate(
+                    LayoutInflater.from(flexboxLayout.context),
+                    flexboxLayout,
+                    false
+                ).root
+            }.let {
+                ItemReactionBinding.bind(it)
+            }
+
+            // Step 2: Bind data to the view
+            binding.apply {
+                reactionLayout.applyBackgroundColor(
+                    reactionData,
+                    currentNote?.toShowNote?.note?.isMisskey ?: false
+                )
+                reactionLayout.bindReactionCount(
+                    reactionText,
+                    reactionImage,
+                    reactionData,
+                    (currentNote?.config?.value?.noteReactionCounterFontSize ?: 15f) * 1.2f
+                )
+                reactionCounter.text = reactionData.reactionCount.count.toString()
+                reactionCounter.setMemoFontSpSize(
+                    currentNote?.config?.value?.noteReactionCounterFontSize ?: 15f
+                )
+            }
+
+            binding.root.setOnLongClickListener {
+                val id = currentNote?.toShowNote?.note?.id
+                if (id != null) {
+                    reactionCountActionListener(
+                        ReactionCountAction.OnLongClicked(
+                            currentNote,
+                            reactionData.reaction
+                        )
+                    )
+                    true
+                } else {
+                    false
+                }
+            }
+            binding.root.setOnClickListener {
+                currentNote?.let {
+                    reactionCountActionListener(ReactionCountAction.OnClicked(currentNote, reactionData.reaction))
+                }
+            }
+
+            // Step 3: Add new view if necessary
+            if (existingBinding == null) {
+                flexboxLayout.addView(binding.root)
+            }
+        }
+    }
+}
+
+class ViewRecycler<T> where T : View {
+
+    private val recycledViews: Stack<T> = Stack()
+
+    /**
+     * 使わなくなったViewをリサイクル用のスタックに追加する
+     */
+    fun recycleView(view: T) {
+        if (recycledViews.size < 40) {
+            recycledViews.push(view)
+        }
+    }
+
+    /**
+     * 必要なビューを取得する。
+     * リサイクルできるビューがあればそれを返し、なければnullを返す。
+     */
+    fun getRecycledView(onInflateView: () -> T): T {
+        return if (recycledViews.isNotEmpty()) {
+            recycledViews.pop()
+        } else {
+            onInflateView()
+        }
+    }
+
+    /**
+     * 現在リサイクル待ちのビューの数を取得する。
+     */
+    fun recycledViewCount(): Int {
+        return recycledViews.size
+    }
+}

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineListAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineListAdapter.kt
@@ -31,7 +31,6 @@ import net.pantasystem.milktea.note.databinding.ItemHasReplyToNoteBinding
 import net.pantasystem.milktea.note.databinding.ItemNoteBinding
 import net.pantasystem.milktea.note.databinding.ItemTimelineEmptyBinding
 import net.pantasystem.milktea.note.databinding.ItemTimelineErrorBinding
-import net.pantasystem.milktea.note.reaction.ReactionCountAdapter
 import net.pantasystem.milktea.note.reaction.ReactionViewData
 import net.pantasystem.milktea.note.timeline.viewmodel.TimelineListItem
 import net.pantasystem.milktea.note.view.NoteCardAction
@@ -124,25 +123,9 @@ class TimelineListAdapter(
         }
 
         private fun bindReactionCounter() {
-            val reactionCountAdapter = ReactionCountAdapter {
-                noteCardActionListenerAdapter.onReactionCountAction(it)
-            }
             val note = mCurrentNote!!
-            reactionCountAdapter.note = note
-
-            val reactionList = note.reactionCountsViewData.value
-//            reactionCountsView.itemAnimator = null
-//            reactionCountsView.layoutManager = getLayoutManager()
-//            reactionCountsView.adapter = reactionCountAdapter
-//            reactionCountsView.isNestedScrollingEnabled = false
-
-            reactionCountAdapter.submitList(reactionList)
             job = note.reactionCountsViewData.onEach { counts ->
-                if (reactionCountAdapter.note?.id == mCurrentNote?.id) {
-//                    reactionCountsView.itemAnimator?.endAnimations()
-                    bindReactionCountVisibility(counts)
-                    reactionCountAdapter.submitList(counts)
-                }
+                bindReactionCountVisibility(counts)
             }.flowWithLifecycle(lifecycleOwner.lifecycle).launchIn(lifecycleOwner.lifecycleScope)
         }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineListAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineListAdapter.kt
@@ -19,8 +19,7 @@ import com.bumptech.glide.ListPreloader.PreloadModelProvider
 import com.bumptech.glide.RequestBuilder
 import com.bumptech.glide.integration.recyclerview.RecyclerViewPreloader
 import com.bumptech.glide.util.FixedPreloadSizeProvider
-import com.google.android.flexbox.AlignItems
-import com.google.android.flexbox.FlexboxLayoutManager
+import com.google.android.flexbox.FlexboxLayout
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -73,19 +72,27 @@ class TimelineListAdapter(
 
     val cardActionListener = NoteCardActionListenerAdapter(onAction)
 
-    private val reactionCounterRecyclerViewPool = RecyclerView.RecycledViewPool().apply {
-        setMaxRecycledViews(0, 30)
+    private val reactionCountItemsFlexboxLayoutBinder = ReactionCountItemsFlexboxLayoutBinder(
+        ViewRecycler(),
+    ) {
+        cardActionListener.onReactionCountAction(it)
     }
+
     private val urlPreviewListRecyclerViewPool = RecyclerView.RecycledViewPool()
     private val manyFilePreviewListViewRecyclerViewPool = RecyclerView.RecycledViewPool()
 
     sealed class TimelineListItemViewHolderBase(view: View) : RecyclerView.ViewHolder(view)
 
-    sealed class NoteViewHolderBase<out T : ViewDataBinding>(view: View) :
+    sealed class NoteViewHolderBase<out T : ViewDataBinding>(
+        view: View,
+        val reactionCountBinder: ReactionCountItemsFlexboxLayoutBinder
+    ) :
         TimelineListItemViewHolderBase(view) {
+
         abstract val binding: T
         abstract val lifecycleOwner: LifecycleOwner
-        abstract val reactionCountsView: RecyclerView
+//        abstract val reactionCountsView: RecyclerView
+        abstract val flexboxLayout: FlexboxLayout
         abstract val noteCardActionListenerAdapter: NoteCardActionListenerAdapter
 
 //        private var reactionCountAdapter: ReactionCountAdapter? = null
@@ -111,7 +118,7 @@ class TimelineListAdapter(
 
         fun unbind() {
             job?.cancel()
-            reactionCountsView.itemAnimator?.endAnimations()
+//            reactionCountsView.itemAnimator?.endAnimations()
 
             mCurrentNote = null
         }
@@ -124,14 +131,15 @@ class TimelineListAdapter(
             reactionCountAdapter.note = note
 
             val reactionList = note.reactionCountsViewData.value
-            reactionCountsView.itemAnimator = null
-            reactionCountsView.layoutManager = getLayoutManager()
-            reactionCountsView.adapter = reactionCountAdapter
-            reactionCountsView.isNestedScrollingEnabled = false
+//            reactionCountsView.itemAnimator = null
+//            reactionCountsView.layoutManager = getLayoutManager()
+//            reactionCountsView.adapter = reactionCountAdapter
+//            reactionCountsView.isNestedScrollingEnabled = false
+
             reactionCountAdapter.submitList(reactionList)
             job = note.reactionCountsViewData.onEach { counts ->
                 if (reactionCountAdapter.note?.id == mCurrentNote?.id) {
-                    reactionCountsView.itemAnimator?.endAnimations()
+//                    reactionCountsView.itemAnimator?.endAnimations()
                     bindReactionCountVisibility(counts)
                     reactionCountAdapter.submitList(counts)
                 }
@@ -139,20 +147,19 @@ class TimelineListAdapter(
         }
 
         private fun bindReactionCountVisibility(reactionCounts: List<ReactionViewData>?) {
-            reactionCountsView.visibility = if (reactionCounts.isNullOrEmpty()) {
+            reactionCountBinder.bindReactionCounts(
+                flexboxLayout,
+                mCurrentNote,
+                reactionCounts ?: emptyList(),
+            )
+
+            flexboxLayout.visibility = if (reactionCounts.isNullOrEmpty()) {
                 View.GONE
             } else {
                 View.VISIBLE
             }
         }
 
-        private fun getLayoutManager(): FlexboxLayoutManager {
-            val flexBoxLayoutManager = FlexboxLayoutManager(reactionCountsView.context)
-            flexBoxLayoutManager.alignItems = AlignItems.STRETCH
-            reactionCountsView.layoutManager = flexBoxLayoutManager
-            flexBoxLayoutManager.recycleChildrenOnDetach = true
-            return flexBoxLayoutManager
-        }
     }
 
     class LoadingViewHolder(view: View) : TimelineListItemViewHolderBase(view)
@@ -177,14 +184,17 @@ class TimelineListAdapter(
         NormalNote, HasReplyToNote, Loading, Empty, Error
     }
 
-    inner class NoteViewHolder(override val binding: ItemNoteBinding) :
-        NoteViewHolderBase<ItemNoteBinding>(binding.root) {
+    inner class NoteViewHolder(override val binding: ItemNoteBinding, binder: ReactionCountItemsFlexboxLayoutBinder) :
+        NoteViewHolderBase<ItemNoteBinding>(binding.root, binder) {
 
         override val lifecycleOwner: LifecycleOwner
             get() = this@TimelineListAdapter.lifecycleOwner
-        override val reactionCountsView: RecyclerView
-            get() = binding.simpleNote.reactionView
+//        override val reactionCountsView: RecyclerView
+//            get() = binding.simpleNote.reactionView
 
+
+        override val flexboxLayout: FlexboxLayout
+            get() = binding.simpleNote.reactionView
 
         override val noteCardActionListenerAdapter: NoteCardActionListenerAdapter
             get() = this@TimelineListAdapter.cardActionListener
@@ -198,13 +208,16 @@ class TimelineListAdapter(
 
     }
 
-    inner class HasReplyToNoteViewHolder(override val binding: ItemHasReplyToNoteBinding) :
-        NoteViewHolderBase<ItemHasReplyToNoteBinding>(binding.root) {
+    inner class HasReplyToNoteViewHolder(override val binding: ItemHasReplyToNoteBinding, binder: ReactionCountItemsFlexboxLayoutBinder) :
+        NoteViewHolderBase<ItemHasReplyToNoteBinding>(binding.root, binder) {
         override val lifecycleOwner: LifecycleOwner
             get() = this@TimelineListAdapter.lifecycleOwner
 
-        override val reactionCountsView: RecyclerView
+        override val flexboxLayout: FlexboxLayout
             get() = binding.simpleNote.reactionView
+
+//        override val reactionCountsView: RecyclerView
+//            get() = binding.simpleNote.reactionView
 
         override val noteCardActionListenerAdapter: NoteCardActionListenerAdapter
             get() = this@TimelineListAdapter.cardActionListener
@@ -287,7 +300,7 @@ class TimelineListAdapter(
                     p0,
                     false
                 )
-                binding.simpleNote.reactionView.setRecycledViewPool(reactionCounterRecyclerViewPool)
+//                binding.simpleNote.reactionView.setRecycledViewPool(reactionCounterRecyclerViewPool)
                 binding.simpleNote.urlPreviewList.setRecycledViewPool(urlPreviewListRecyclerViewPool)
                 binding.simpleNote.manyFilePreviewListView.setRecycledViewPool(
                     manyFilePreviewListViewRecyclerViewPool
@@ -296,7 +309,7 @@ class TimelineListAdapter(
                     headerFontSize = config.noteHeaderFontSize,
                     contentFontSize = config.noteContentFontSize,
                 )
-                NoteViewHolder(binding)
+                NoteViewHolder(binding, reactionCountItemsFlexboxLayoutBinder)
             }
 
             ViewHolderType.HasReplyToNote -> {
@@ -306,7 +319,7 @@ class TimelineListAdapter(
                     p0,
                     false
                 )
-                binding.simpleNote.reactionView.setRecycledViewPool(reactionCounterRecyclerViewPool)
+//                binding.simpleNote.reactionView.setRecycledViewPool(reactionCounterRecyclerViewPool)
                 binding.simpleNote.urlPreviewList.setRecycledViewPool(urlPreviewListRecyclerViewPool)
                 binding.simpleNote.manyFilePreviewListView.setRecycledViewPool(
                     manyFilePreviewListViewRecyclerViewPool
@@ -315,7 +328,7 @@ class TimelineListAdapter(
                     headerFontSize = config.noteHeaderFontSize,
                     contentFontSize = config.noteContentFontSize,
                 )
-                HasReplyToNoteViewHolder(binding)
+                HasReplyToNoteViewHolder(binding, reactionCountItemsFlexboxLayoutBinder)
             }
 
             ViewHolderType.Loading -> {
@@ -379,7 +392,7 @@ class TimelineListAdapter(
             simpleNote.subNoteMediaPreview.thumbnailBottomRight,
 
             )
-        simpleNote.reactionView.itemAnimator?.endAnimations()
+//        simpleNote.reactionView.itemAnimator?.endAnimations()
 
         imageViews.map {
             Glide.with(simpleNote.avatarIcon).clear(it)

--- a/modules/features/note/src/main/res/layout/item_detail_note.xml
+++ b/modules/features/note/src/main/res/layout/item_detail_note.xml
@@ -378,7 +378,7 @@
                     android:textStyle="bold"
                     android:layout_alignParentEnd="true" />
 
-            <androidx.recyclerview.widget.RecyclerView
+            <com.google.android.flexbox.FlexboxLayout
                     android:id="@+id/reaction_view"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/modules/features/note/src/main/res/layout/item_simple_note.xml
+++ b/modules/features/note/src/main/res/layout/item_simple_note.xml
@@ -398,7 +398,7 @@
             app:layout_constraintStart_toEndOf="@id/avatarIcon"
             app:layout_constraintTop_toBottomOf="@id/autoExpanded" />
 
-        <androidx.recyclerview.widget.RecyclerView
+        <com.google.android.flexbox.FlexboxLayout
             android:id="@+id/reaction_view"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -410,7 +410,9 @@
             app:layout_constraintTop_toBottomOf="@id/channelInfoView"
             tools:itemCount="1"
             tools:listitem="@layout/item_reaction"
-            tools:visibility="visible" />
+            tools:visibility="visible"
+            app:flexWrap="wrap"
+            />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/expandAllReactionCounts"

--- a/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationListAdapter.kt
+++ b/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationListAdapter.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.flexbox.AlignItems
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexWrap
+import com.google.android.flexbox.FlexboxLayout
 import com.google.android.flexbox.FlexboxLayoutManager
 import com.google.android.flexbox.JustifyContent
 import kotlinx.coroutines.Job
@@ -22,6 +23,8 @@ import net.pantasystem.milktea.model.setting.DefaultConfig
 import net.pantasystem.milktea.model.setting.LocalConfigRepository
 import net.pantasystem.milktea.note.reaction.ReactionCountAdapter
 import net.pantasystem.milktea.note.timeline.NoteFontSizeBinder
+import net.pantasystem.milktea.note.timeline.ReactionCountItemsFlexboxLayoutBinder
+import net.pantasystem.milktea.note.timeline.ViewRecycler
 import net.pantasystem.milktea.note.view.NoteCardAction
 import net.pantasystem.milktea.note.view.NoteCardActionListenerAdapter
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
@@ -45,6 +48,11 @@ class NotificationListAdapter constructor(
 
 
     private val noteCardActionListenerAdapter = NoteCardActionListenerAdapter(onNoteCardAction)
+    private val binder = ReactionCountItemsFlexboxLayoutBinder(
+        ViewRecycler()
+    ) {
+        noteCardActionListenerAdapter.onReactionCountAction(it)
+    }
 
     override fun getItemViewType(position: Int): Int {
         return when (getItem(position)) {
@@ -119,7 +127,8 @@ class NotificationListAdapter constructor(
                     ),
                     lifecycleOwner,
                     notificationViewModel,
-                    noteCardActionListenerAdapter
+                    noteCardActionListenerAdapter,
+                    binder,
                 ).also {
                     val config = configRepository.get().getOrElse {
                         DefaultConfig.config
@@ -145,6 +154,7 @@ class NotificationViewHolder(
     private val lifecycleOwner: LifecycleOwner,
     private val notificationViewModel: NotificationViewModel,
     private val noteCardActionListenerAdapter: NoteCardActionListenerAdapter,
+    private val binder: ReactionCountItemsFlexboxLayoutBinder,
 ) : NotificationBaseViewHolder(binding.root) {
     fun onBind(item: NotificationListItem.Notification) {
         binding.notification = item.notificationViewData
@@ -154,38 +164,25 @@ class NotificationViewHolder(
         val note = item.notificationViewData.noteViewData
         note ?: return
 
-//        setReactionCounter(note, binding.simpleNote.reactionView)
+        setReactionCounter(note, binding.simpleNote.reactionView)
         binding.lifecycleOwner = lifecycleOwner
         binding.executePendingBindings()
     }
 
     private var job: Job? = null
 
-    private fun setReactionCounter(note: PlaneNoteViewData, reactionView: RecyclerView) {
+    private fun setReactionCounter(note: PlaneNoteViewData, reactionView: FlexboxLayout) {
 
         val reactionList = note.reactionCountsViewData.value
-        val adapter = ReactionCountAdapter {
-            noteCardActionListenerAdapter.onReactionCountAction(it)
-        }
-        adapter.note = note
-        reactionView.adapter = adapter
 
-        adapter.submitList(reactionList)
+
 
         job?.cancel()
         job = note.reactionCountsViewData.onEach {
-            adapter.submitList(it)
+
+            binder.bindReactionCounts(reactionView, note, it)
         }.flowWithLifecycle(lifecycleOwner.lifecycle).launchIn(lifecycleOwner.lifecycleScope)
 
-        val exLayoutManager = reactionView.layoutManager
-        if (exLayoutManager !is FlexboxLayoutManager) {
-            val flexBoxLayoutManager = FlexboxLayoutManager(reactionView.context)
-            flexBoxLayoutManager.flexDirection = FlexDirection.ROW
-            flexBoxLayoutManager.flexWrap = FlexWrap.WRAP
-            flexBoxLayoutManager.justifyContent = JustifyContent.FLEX_START
-            flexBoxLayoutManager.alignItems = AlignItems.STRETCH
-            reactionView.layoutManager = flexBoxLayoutManager
-        }
 
         if (reactionList.isNotEmpty()) {
             reactionView.visibility = View.VISIBLE

--- a/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationListAdapter.kt
+++ b/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationListAdapter.kt
@@ -10,7 +10,11 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.flexbox.*
+import com.google.android.flexbox.AlignItems
+import com.google.android.flexbox.FlexDirection
+import com.google.android.flexbox.FlexWrap
+import com.google.android.flexbox.FlexboxLayoutManager
+import com.google.android.flexbox.JustifyContent
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -150,7 +154,7 @@ class NotificationViewHolder(
         val note = item.notificationViewData.noteViewData
         note ?: return
 
-        setReactionCounter(note, binding.simpleNote.reactionView)
+//        setReactionCounter(note, binding.simpleNote.reactionView)
         binding.lifecycleOwner = lifecycleOwner
         binding.executePendingBindings()
     }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/reaction/UserReactionsListAdapter.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/reaction/UserReactionsListAdapter.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.flexbox.FlexboxLayoutManager
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -73,12 +72,12 @@ class UserReactionViewHolder(
     private var job: Job? = null
     fun bind(item: UserReactionBindingModel) {
         val listView = binding.simpleNote.reactionView
-        listView.layoutManager = FlexboxLayoutManager(binding.root.context)
+//        listView.layoutManager = FlexboxLayoutManager(binding.root.context)
         val adapter = ReactionCountAdapter {
             noteCardActionListenerAdapter.onReactionCountAction(it)
         }
         adapter.note = item.note
-        listView.adapter = adapter
+//        listView.adapter = adapter
         binding.noteCardActionListener = noteCardActionListenerAdapter
         binding.bindingModel = item
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -99,7 +99,7 @@ dependencyResolutionManagement {
 
             library("kotlin-serialization", "org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
 
-            library("recyclerview", "androidx.recyclerview:recyclerview:1.3.0")
+            library("recyclerview", "androidx.recyclerview:recyclerview:1.3.1")
 
             library("objectbox-kotlin", "io.objectbox:objectbox-kotlin:3.5.1")
         }


### PR DESCRIPTION
## やったこと
現状発生している不具合がRecyclerViewをネストさせることによって発生している不具合の可能性が高いため、
RecyclerViewを用いらない実装をしてみました。


## 動作確認
エミュレーターで動作することを確認しました。

## スクリーンショット(任意)


## 備考
パフォーマンス面がRecyclerViewの時とどれぐらい変わるのかよくわかっていないです。

## Issue番号


