### PR TITLE
リモートのカスタム絵文字をキャッシュできるようにした　

### DIFF
--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/BindingProvider.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/BindingProvider.kt
@@ -11,6 +11,7 @@ import net.pantasystem.milktea.common_navigation.SearchNavigation
 import net.pantasystem.milktea.common_navigation.UserDetailNavigation
 import net.pantasystem.milktea.model.emoji.CustomEmojiAspectRatioStore
 import net.pantasystem.milktea.model.emoji.CustomEmojiRepository
+import net.pantasystem.milktea.model.emoji.EmojiImageCacheStore
 import net.pantasystem.milktea.model.setting.ColorSettingStore
 import net.pantasystem.milktea.model.setting.LocalConfigRepository
 
@@ -36,4 +37,6 @@ interface BindingProvider {
     fun customEmojiAspectRatioStore(): CustomEmojiAspectRatioStore
 
     fun configRepository(): LocalConfigRepository
+
+    fun emojiImageCacheStore(): EmojiImageCacheStore
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/SaveImageAspectRequestListener.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/SaveImageAspectRequestListener.kt
@@ -40,6 +40,8 @@ class SaveImageAspectRequestListener(
             emoji, imageAspectRatio
         )
         ImageAspectRatioCache.put(emoji.url ?: emoji.uri, imageAspectRatio)
+        navigationEntryPoint.emojiImageCacheStore().save(emoji)
+
 
         return false
     }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/emoji/EmojiImageCacheStore.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/emoji/EmojiImageCacheStore.kt
@@ -1,0 +1,41 @@
+package net.pantasystem.milktea.model.emoji
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onEach
+import net.pantasystem.milktea.common.Logger
+import net.pantasystem.milktea.model.image.ImageCacheRepository
+import javax.inject.Inject
+
+class EmojiImageCacheStore @Inject constructor(
+    coroutineScope: CoroutineScope,
+    private val imageCacheRepository: ImageCacheRepository,
+    private val loggerFactory: Logger.Factory,
+) {
+
+    private val logger by lazy {
+        loggerFactory.create("EICStore")
+    }
+
+    private val queue = MutableSharedFlow<Emoji>(extraBufferCapacity = 100)
+
+    init {
+        queue.mapNotNull { emoji ->
+            emoji.url ?: emoji.uri
+        }.onEach { url ->
+            try {
+                imageCacheRepository.save(url)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.error("save failure", e)
+            }
+        }.launchIn(coroutineScope)
+    }
+    fun save(emoji: Emoji) {
+        queue.tryEmit(emoji)
+    }
+}


### PR DESCRIPTION
## やったこと
リモートのカスタム絵文字をキャッシュできるようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1826 


