### PR TITLE
プロフィールをQRコードで共有できるようにした

### DIFF
--- a/modules/common_resource/src/main/res/menu/activity_user_menu.xml
+++ b/modules/common_resource/src/main/res/menu/activity_user_menu.xml
@@ -50,4 +50,9 @@
             android:id="@+id/nav_switch_account"
             android:title="@string/switch_account"
         />
+
+    <item
+        android:id="@+id/show_qr_code"
+        android:title="@string/qr_code"
+        />
 </menu>

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -620,6 +620,7 @@
     <string name="media_display_mode_default">デフォルト</string>
     <string name="media_display_mode_always">常にメディアを非表示</string>
     <string name="misskey_role_drive_no_free_space_error_message">ドライブの空き容量がないため、ファイルをアップロードできません。</string>
+    <string name="qr_code">QRコード</string>
     <!-- User -->
 
 

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -621,6 +621,7 @@
     <string name="media_display_mode_always">常にメディアを非表示</string>
     <string name="misskey_role_drive_no_free_space_error_message">ドライブの空き容量がないため、ファイルをアップロードできません。</string>
     <string name="qr_code">QRコード</string>
+    <string name="copy">コピー</string>
     <!-- User -->
 
 

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -611,6 +611,7 @@
     <string name="media_display_mode_default">Default</string>
     <string name="media_display_mode_always">Always hide</string>
     <string name="misskey_role_drive_no_free_space_error_message">无法上传文件，因为硬盘没有可用空间</string>
+    <string name="qr_code">QR Code</string>
     <!-- User -->
 
 </resources>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -612,6 +612,7 @@
     <string name="media_display_mode_always">Always hide</string>
     <string name="misskey_role_drive_no_free_space_error_message">无法上传文件，因为硬盘没有可用空间</string>
     <string name="qr_code">QR Code</string>
+    <string name="copy">Copy</string>
     <!-- User -->
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -619,6 +619,7 @@
     <string name="media_display_mode_default">Default</string>
     <string name="media_display_mode_always">Always hide media</string>
     <string name="misskey_role_drive_no_free_space_error_message">Cannot upload the file because you have no free space of drive.</string>
+    <string name="qr_code">QR Code</string>
     <!-- reaction-acceptance -->
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -620,6 +620,7 @@
     <string name="media_display_mode_always">Always hide media</string>
     <string name="misskey_role_drive_no_free_space_error_message">Cannot upload the file because you have no free space of drive.</string>
     <string name="qr_code">QR Code</string>
+    <string name="copy">Copy</string>
     <!-- reaction-acceptance -->
 
 </resources>

--- a/modules/features/user/build.gradle
+++ b/modules/features/user/build.gradle
@@ -118,4 +118,7 @@ dependencies {
 
     testImplementation libs.junit.jupiter.api
     testRuntimeOnly libs.junit.jupiter.engine
+
+    implementation 'com.github.kenglxn.QRGen:android:3.0.1'
+
 }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/UserDetailActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/UserDetailActivity.kt
@@ -42,11 +42,12 @@ import net.pantasystem.milktea.note.NoteEditorActivity
 import net.pantasystem.milktea.note.view.ActionNoteHandler
 import net.pantasystem.milktea.note.viewmodel.NotesViewModel
 import net.pantasystem.milktea.user.R
-import net.pantasystem.milktea.user.followlist.FollowFollowerActivity
 import net.pantasystem.milktea.user.databinding.ActivityUserDetailBinding
+import net.pantasystem.milktea.user.followlist.FollowFollowerActivity
 import net.pantasystem.milktea.user.nickname.EditNicknameDialog
 import net.pantasystem.milktea.user.profile.mute.SpecifyMuteExpiredAtDialog
 import net.pantasystem.milktea.user.profile.viewmodel.UserDetailViewModel
+import net.pantasystem.milktea.user.qrshare.QRShareDialog
 import javax.inject.Inject
 
 class UserDetailNavigationImpl @Inject constructor(
@@ -400,6 +401,9 @@ class UserDetailActivity : AppCompatActivity() {
             }
             R.id.nav_switch_account -> {
                 ProfileAccountSwitchDialog().show(supportFragmentManager, "switchAccountDialog")
+            }
+            R.id.show_qr_code -> {
+                QRShareDialog().show(supportFragmentManager, "QRShareDialog")
             }
             else -> return false
 

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/viewmodel/UserDetailViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/viewmodel/UserDetailViewModel.kt
@@ -112,6 +112,13 @@ class UserDetailViewModel @Inject constructor(
         _errors.tryEmit(it)
     }.stateIn(viewModelScope, SharingStarted.Lazily, null)
 
+    val originProfileUrl = userState.filterNotNull().map {
+        val account = accountRepository.get(it.id.accountId).getOrThrow()
+        it.getRemoteProfileUrl(account)
+    }.catch {
+        logger.error("get profile url error", it)
+    }.stateIn(viewModelScope, SharingStarted.Lazily, null)
+
     val isMine = combine(userState, currentAccount) { userState, account ->
         userState?.id?.id == account?.remoteId
     }.stateIn(viewModelScope, SharingStarted.Lazily, false)

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/viewmodel/UserDetailViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/viewmodel/UserDetailViewModel.kt
@@ -54,6 +54,7 @@ class UserDetailViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val userDetailTabTypeFactory: UserDetailTabTypeFactory,
     private val toggleUserTimelineAddTabUseCase: ToggleUserTimelineAddTabUseCase,
+    private val userIdResolver: UserIdResolver,
     configRepository: LocalConfigRepository,
 ) : ViewModel() {
 
@@ -323,38 +324,11 @@ class UserDetailViewModel @Inject constructor(
         val strUserId = savedStateHandle.get<String?>(UserDetailActivity.EXTRA_USER_ID)
         val specifiedAccountId = savedStateHandle.get<Long?>(UserDetailActivity.EXTRA_ACCOUNT_ID)
         val fqdnUserName = savedStateHandle.get<String?>(UserDetailActivity.EXTRA_USER_NAME)
-        val currentAccount = specifiedAccountId?.let {
-            accountRepository.get(it).getOrThrow()
-        } ?: accountRepository.getCurrentAccount().getOrThrow()
-        val argType = when {
-            strUserId != null -> {
-                UserProfileArgType.UserId(User.Id(currentAccount.accountId, strUserId))
-            }
-
-            fqdnUserName != null -> {
-                UserProfileArgType.FqdnUserName(fqdnUserName, currentAccount)
-            }
-
-            else -> {
-                UserProfileArgType.None
-            }
-        }
-
-        when (argType) {
-            is UserProfileArgType.FqdnUserName -> {
-                val (userName, host) = Acct(argType.fqdnUserName).let {
-                    it.userName to it.host
-                }
-                userRepository.findByUserName(currentAccount.accountId, userName, host).id
-            }
-
-            is UserProfileArgType.UserId -> {
-                argType.userId
-            }
-
-            UserProfileArgType.None -> throw IllegalStateException()
-        }
-
+        userIdResolver(
+            userId = strUserId,
+            acct = fqdnUserName,
+            specifiedAccountId = specifiedAccountId,
+        ).getOrThrow()
     }
 }
 

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/viewmodel/UserIdResolver.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/viewmodel/UserIdResolver.kt
@@ -1,0 +1,54 @@
+package net.pantasystem.milktea.user.profile.viewmodel
+
+import net.pantasystem.milktea.common.runCancellableCatching
+import net.pantasystem.milktea.model.account.AccountRepository
+import net.pantasystem.milktea.model.user.Acct
+import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.model.user.UserRepository
+import javax.inject.Inject
+
+class UserIdResolver @Inject constructor(
+    val accountRepository: AccountRepository,
+    val userRepository: UserRepository,
+) {
+
+    suspend operator fun invoke(
+        userId: String?,
+        acct: String?,
+        specifiedAccountId: Long?,
+    ): Result<User.Id> = runCancellableCatching {
+        val currentAccount = specifiedAccountId?.let {
+            accountRepository.get(it).getOrThrow()
+        } ?: accountRepository.getCurrentAccount().getOrThrow()
+        val argType = when {
+            userId != null -> {
+                UserProfileArgType.UserId(User.Id(currentAccount.accountId, userId
+                ))
+            }
+
+            acct != null -> {
+                UserProfileArgType.FqdnUserName(acct, currentAccount)
+            }
+
+            else -> {
+                UserProfileArgType.None
+            }
+        }
+
+        when (argType) {
+            is UserProfileArgType.FqdnUserName -> {
+                val (userName, host) = Acct(argType.fqdnUserName).let {
+                    it.userName to it.host
+                }
+                userRepository.findByUserName(currentAccount.accountId, userName, host).id
+            }
+
+            is UserProfileArgType.UserId -> {
+                argType.userId
+            }
+
+            UserProfileArgType.None -> throw IllegalStateException()
+        }
+
+    }
+}

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/qrshare/QRCodeBitmapGenerator.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/qrshare/QRCodeBitmapGenerator.kt
@@ -1,0 +1,88 @@
+package net.pantasystem.milktea.user.qrshare
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import com.bumptech.glide.Glide
+import com.bumptech.glide.request.FutureTarget
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import net.glxn.qrgen.android.QRCode
+import net.pantasystem.milktea.common.runCancellableCatching
+import net.pantasystem.milktea.model.account.AccountRepository
+import net.pantasystem.milktea.model.user.User
+import javax.inject.Inject
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+
+class QRCodeBitmapGenerator @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val accountRepository: AccountRepository,
+) {
+    suspend operator fun invoke(
+        user: User,
+        size: Int,
+    ): Result<Bitmap?> = runCancellableCatching {
+        val qrCode = QRCode.from(
+            user.getProfileUrl(accountRepository.get(user.id.accountId).getOrThrow()),
+        ).withSize(size, size).bitmap()
+            ?: return@runCancellableCatching null
+
+        val avatarIcon = user.avatarUrl?.let {
+            withContext(Dispatchers.IO) {
+                loadProfileGlide(it, size / 8)
+            }
+        }
+        overlayBitmapsCentered(avatarIcon, qrCode)
+    }
+
+
+    private fun overlayBitmapsCentered(avatarIcon: Bitmap?, qrCode: Bitmap): Bitmap {
+        // 重ねるための新しいBitmapを生成
+        val result = Bitmap.createBitmap(
+            qrCode.width,
+            qrCode.height,
+            qrCode.config
+        )
+
+        val canvas = Canvas(result)
+        canvas.drawBitmap(qrCode, 0f, 0f, null)
+
+        if (avatarIcon != null) {
+            val left = (qrCode.width - avatarIcon.width) / 2.0f
+            val top = (qrCode.height - avatarIcon.height) / 2.0f
+
+            canvas.drawBitmap(avatarIcon, left, top, null)
+        }
+        // Bitmap AをBitmap Bの中央に描画するための座標を計算
+
+
+        return result
+    }
+
+    private suspend fun loadProfileGlide(
+        avatarUrl: String,
+        size: Int,
+    ): Bitmap? {
+        return suspendCoroutine<Bitmap?> { continuation ->
+            val futureTarget: FutureTarget<Bitmap> = Glide
+                .with(context)
+                .asBitmap()
+                .circleCrop()
+                .override(size)
+                .load(avatarUrl)
+                .submit()
+
+            try {
+                val bitmap = futureTarget.get()  // この呼び出しはブロックされ、ロードが完了するまで待機します
+                continuation.resume(bitmap)
+            } catch (e: Exception) {
+                continuation.resume(null)  // エラーが発生した場合、nullを返す
+            } finally {
+                Glide.with(context).clear(futureTarget)  // 必ずクリアすること
+            }
+        }
+    }
+}

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/qrshare/QRShareDialog.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/qrshare/QRShareDialog.kt
@@ -1,0 +1,147 @@
+package net.pantasystem.milktea.user.qrshare
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import dagger.hilt.android.AndroidEntryPoint
+import net.glxn.qrgen.android.QRCode
+import net.pantasystem.milktea.common_compose.MilkteaStyleConfigApplyAndTheme
+import net.pantasystem.milktea.model.setting.LocalConfigRepository
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class QRShareDialog : AppCompatDialogFragment() {
+
+    @Inject
+    internal lateinit var configRepository: LocalConfigRepository
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return MaterialAlertDialogBuilder(requireContext()).also { builder ->
+            builder.setView(
+                ComposeView(requireContext()).apply {
+                    setContent {
+                        MilkteaStyleConfigApplyAndTheme(configRepository = configRepository) {
+                            Surface {
+                                var qrBitmap by remember {
+                                    mutableStateOf<ImageBitmap?>(null)
+                                }
+                                DisposableEffect(Unit) {
+                                    qrBitmap = QRCode.from(
+                                        "https://calc.panta.systems/@Panta",
+                                    ).withSize(512, 512).bitmap().asImageBitmap()
+                                    onDispose {
+                                        qrBitmap = null
+                                    }
+                                }
+
+                                Column(
+                                    Modifier.padding(32.dp),
+                                    horizontalAlignment = Alignment.CenterHorizontally,
+                                ) {
+                                    BoxWithConstraints(
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .aspectRatio(1f),
+                                    ) {
+                                        val height = this.maxHeight
+                                        val width = this.maxWidth
+
+                                        val density = LocalDensity.current
+                                        val size = remember(height, width) {
+                                            if (height > width) width else height
+                                        }
+                                        val sizePx = with(density) {
+                                            size.toPx()
+                                        }
+                                        DisposableEffect(Unit) {
+
+                                            qrBitmap = QRCode.from(
+                                                "https://calc.panta.systems/@Panta",
+                                            ).withSize(
+                                                sizePx.toInt(),
+                                                sizePx.toInt(),
+                                            ).bitmap().asImageBitmap()
+                                            onDispose {
+                                                qrBitmap = null
+                                            }
+                                        }
+                                        when (qrBitmap) {
+                                            null -> Unit
+                                            else -> Image(
+                                                qrBitmap!!,
+                                                contentDescription = null,
+                                                Modifier.fillMaxSize()
+                                            )
+                                        }
+                                    }
+                                    Spacer(modifier = Modifier.heightIn(16.dp))
+                                    Text("@Panta@calc.panta.systems", fontWeight = FontWeight.Bold)
+                                    Spacer(modifier = Modifier.heightIn(16.dp))
+                                    Row(
+                                        Modifier
+                                            .fillMaxWidth(),
+                                        horizontalArrangement = Arrangement.SpaceBetween,
+                                    ) {
+                                        Column(
+                                            horizontalAlignment = Alignment.CenterHorizontally,
+                                        ) {
+                                            Icon(Icons.Default.Link, contentDescription = null)
+                                            Text("コピー")
+                                        }
+
+                                        Column(
+                                            horizontalAlignment = Alignment.CenterHorizontally,
+                                        ) {
+                                            Icon(Icons.Default.Share, contentDescription = null)
+                                            Text("共有")
+                                        }
+
+                                        Column(
+                                            horizontalAlignment = Alignment.CenterHorizontally,
+                                        ) {
+                                            Icon(Icons.Default.Save, contentDescription = null)
+                                            Text("保存")
+                                        }
+                                    }
+
+
+                                }
+                            }
+                        }
+                    }
+                }
+            )
+        }.create()
+    }
+}

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/qrshare/QRShareDialog.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/qrshare/QRShareDialog.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.activityViewModels
@@ -184,7 +185,7 @@ fun QRShareDialogLayout(
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Icon(Icons.Default.Link, contentDescription = null)
-                    Text("コピー")
+                    Text(stringResource(id = R.string.copy))
                 }
 
                 Column(
@@ -197,7 +198,7 @@ fun QRShareDialogLayout(
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Icon(Icons.Default.Share, contentDescription = null)
-                    Text("共有")
+                    Text(stringResource(id = R.string.share))
                 }
 
                 Column(
@@ -208,7 +209,7 @@ fun QRShareDialogLayout(
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Icon(Icons.Default.Save, contentDescription = null)
-                    Text("保存")
+                    Text(stringResource(id = R.string.save))
                 }
             }
         }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/qrshare/QRShareDialog.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/qrshare/QRShareDialog.kt
@@ -4,7 +4,10 @@ import android.app.Dialog
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -14,6 +17,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
@@ -21,24 +26,32 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.fragment.app.activityViewModels
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import net.glxn.qrgen.android.QRCode
+import net.pantasystem.milktea.common_compose.AvatarIcon
 import net.pantasystem.milktea.common_compose.MilkteaStyleConfigApplyAndTheme
 import net.pantasystem.milktea.model.setting.LocalConfigRepository
+import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.user.profile.viewmodel.UserDetailViewModel
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -46,102 +59,127 @@ class QRShareDialog : AppCompatDialogFragment() {
 
     @Inject
     internal lateinit var configRepository: LocalConfigRepository
+
+    val viewModel by activityViewModels<UserDetailViewModel>()
+
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         return MaterialAlertDialogBuilder(requireContext()).also { builder ->
             builder.setView(
                 ComposeView(requireContext()).apply {
                     setContent {
                         MilkteaStyleConfigApplyAndTheme(configRepository = configRepository) {
-                            Surface {
-                                var qrBitmap by remember {
-                                    mutableStateOf<ImageBitmap?>(null)
-                                }
-                                DisposableEffect(Unit) {
-                                    qrBitmap = QRCode.from(
-                                        "https://calc.panta.systems/@Panta",
-                                    ).withSize(512, 512).bitmap().asImageBitmap()
-                                    onDispose {
-                                        qrBitmap = null
-                                    }
-                                }
-
-                                Column(
-                                    Modifier.padding(32.dp),
-                                    horizontalAlignment = Alignment.CenterHorizontally,
-                                ) {
-                                    BoxWithConstraints(
-                                        Modifier
-                                            .fillMaxWidth()
-                                            .aspectRatio(1f),
-                                    ) {
-                                        val height = this.maxHeight
-                                        val width = this.maxWidth
-
-                                        val density = LocalDensity.current
-                                        val size = remember(height, width) {
-                                            if (height > width) width else height
-                                        }
-                                        val sizePx = with(density) {
-                                            size.toPx()
-                                        }
-                                        DisposableEffect(Unit) {
-
-                                            qrBitmap = QRCode.from(
-                                                "https://calc.panta.systems/@Panta",
-                                            ).withSize(
-                                                sizePx.toInt(),
-                                                sizePx.toInt(),
-                                            ).bitmap().asImageBitmap()
-                                            onDispose {
-                                                qrBitmap = null
-                                            }
-                                        }
-                                        when (qrBitmap) {
-                                            null -> Unit
-                                            else -> Image(
-                                                qrBitmap!!,
-                                                contentDescription = null,
-                                                Modifier.fillMaxSize()
-                                            )
-                                        }
-                                    }
-                                    Spacer(modifier = Modifier.heightIn(16.dp))
-                                    Text("@Panta@calc.panta.systems", fontWeight = FontWeight.Bold)
-                                    Spacer(modifier = Modifier.heightIn(16.dp))
-                                    Row(
-                                        Modifier
-                                            .fillMaxWidth(),
-                                        horizontalArrangement = Arrangement.SpaceBetween,
-                                    ) {
-                                        Column(
-                                            horizontalAlignment = Alignment.CenterHorizontally,
-                                        ) {
-                                            Icon(Icons.Default.Link, contentDescription = null)
-                                            Text("コピー")
-                                        }
-
-                                        Column(
-                                            horizontalAlignment = Alignment.CenterHorizontally,
-                                        ) {
-                                            Icon(Icons.Default.Share, contentDescription = null)
-                                            Text("共有")
-                                        }
-
-                                        Column(
-                                            horizontalAlignment = Alignment.CenterHorizontally,
-                                        ) {
-                                            Icon(Icons.Default.Save, contentDescription = null)
-                                            Text("保存")
-                                        }
-                                    }
-
-
-                                }
-                            }
+                            val user by viewModel.userState.collectAsState()
+                            QRShareDialogLayout(user)
                         }
                     }
                 }
             )
         }.create()
+    }
+}
+
+@Composable
+fun QRShareDialogLayout(
+    user: User?,
+) {
+    Surface {
+        var qrBitmap by remember {
+            mutableStateOf<ImageBitmap?>(null)
+        }
+
+        Column(
+            Modifier.padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            BoxWithConstraints(
+                Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1f),
+            ) {
+                val height = this.maxHeight
+                val width = this.maxWidth
+
+                val density = LocalDensity.current
+                val size = remember(height, width) {
+                    if (height > width) width else height
+                }
+                val sizePx = with(density) {
+                    size.toPx()
+                }
+                DisposableEffect(user?.displayUserName) {
+
+                    if (user != null) {
+                        qrBitmap = QRCode.from(
+                            user.displayUserName,
+                        ).withSize(
+                            sizePx.toInt(),
+                            sizePx.toInt(),
+                        ).bitmap().asImageBitmap()
+
+                    }
+                    onDispose {
+                        qrBitmap = null
+                    }
+                }
+                when (val bitmap = qrBitmap) {
+                    null -> Unit
+                    else -> Image(
+                        bitmap,
+                        contentDescription = null,
+                        Modifier.fillMaxSize()
+                    )
+                }
+
+                Box(
+                    modifier = Modifier
+                        .size(size / 8)
+                        .align(Alignment.Center)
+                        .background(Color.White)
+                        .padding(size / 64)
+                        .clip(RoundedCornerShape(2.dp))
+                ) {
+                    AvatarIcon(url = user?.avatarUrl, modifier = Modifier.fillMaxSize())
+                }
+
+            }
+            Spacer(modifier = Modifier.heightIn(16.dp))
+            Text(user?.displayUserName ?: "", fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.heightIn(16.dp))
+            Row(
+                Modifier
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Column(
+                    Modifier.clickable {
+
+                    },
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Icon(Icons.Default.Link, contentDescription = null)
+                    Text("コピー")
+                }
+
+                Column(
+                    Modifier.clickable {
+
+                    },
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Icon(Icons.Default.Share, contentDescription = null)
+                    Text("共有")
+                }
+
+                Column(
+                    Modifier.clickable {
+
+                    },
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Icon(Icons.Default.Save, contentDescription = null)
+                    Text("保存")
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## やったこと
プロフィールのURLをもとにQRコードを生成し、
そのQRコードを画像として保存、共有できるようにしました。
またURLをクリップボードへコピーできるようにしました。

## 動作確認
QRの生成ができることを確認しました。
QRを保存できることを確認しました。
生成したQRをスマホからスキャンできることを確認しました。


## スクリーンショット(任意)
|メニュー表示時|QR表示時|
|-|-|
|<img width="434" alt="スクリーンショット 2023-08-17 21 51 09" src="https://github.com/pantasystem/Milktea/assets/38454985/4e11218f-3821-4763-aa8a-e88f526a0cbe">|<img width="433" alt="スクリーンショット 2023-08-17 21 50 59" src="https://github.com/pantasystem/Milktea/assets/38454985/806db343-c092-4240-8dac-eaec25226ae6">|

## 備考


## Issue番号
Closed #1802 

