### PR TITLE
カスタム絵文字のaliasがメモリ上にできる限り展開されないようにした

### DIFF
--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/objectbox/CustomEmojiRecord.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/objectbox/CustomEmojiRecord.kt
@@ -43,7 +43,7 @@ data class CustomEmojiRecord(
         aliases = model.aliases?.toMutableList() ?: mutableListOf()
     }
 
-    fun toModel(aspectRatio: Float? = null, cachePath: String? = null): Emoji {
+    fun toModel(aspectRatio: Float? = null, cachePath: String? = null, needAlias: Boolean = false): Emoji {
         return Emoji(
             id = serverId,
             name = name,
@@ -52,7 +52,7 @@ data class CustomEmojiRecord(
             uri = uri,
             type = type,
             category = category,
-            aliases = aliases,
+            aliases = if (needAlias) aliases else null,
             aspectRatio = aspectRatio,
             cachePath = cachePath,
         )

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/EmojiPickerUiState.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/EmojiPickerUiState.kt
@@ -50,7 +50,7 @@ class EmojiPickerUiStateService(
     private val emojis = account
         .filterNotNull()
         .flatMapLatest { ac ->
-            customEmojiRepository.observeBy(ac.getHost())
+            customEmojiRepository.observeBy(ac.getHost(), withAliases = true)
         }.catch {
             logger.error("絵文字の取得に失敗", it)
         }.flowOn(Dispatchers.IO)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/EmojiPickerUiState.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/EmojiPickerUiState.kt
@@ -108,7 +108,7 @@ class EmojiPickerUiStateService(
     private val filteredEmojis = combine(searchWord, account.filterNotNull()) { word, ac ->
         word to ac
     }.flatMapLatest { (word, ac) ->
-        customEmojiRepository.observeWithSearch(host = ac.getHost(), keyword = word).map {
+        customEmojiRepository.observeWithSearch(host = ac.getHost(), keyword = word.replace(":", "")).map {
             it.sortedBy { emoji ->
                 LevenshteinDistance(emoji.name, word)
             }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
@@ -284,7 +284,7 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
 
 
         accountViewModel.currentAccount.filterNotNull().flatMapLatest {
-            customEmojiRepository.observeBy(it.getHost())
+            customEmojiRepository.observeBy(it.getHost(), withAliases = true)
         }.distinctUntilChanged().onEach { emojis ->
             binding.inputMain.setAdapter(
                 CustomEmojiCompleteAdapter(

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/emoji/CustomEmojiRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/emoji/CustomEmojiRepository.kt
@@ -19,6 +19,8 @@ interface CustomEmojiRepository {
 
     fun observeBy(host: String, withAliases: Boolean = false): Flow<List<Emoji>>
 
+    fun observeWithSearch(host: String, keyword: String): Flow<List<Emoji>>
+
     fun get(host: String): List<Emoji>?
 
     fun getAndConvertToMap(host: String): Map<String, Emoji>?

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/emoji/CustomEmojiRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/emoji/CustomEmojiRepository.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface CustomEmojiRepository {
 
-    suspend fun findBy(host: String): Result<List<Emoji>>
+    suspend fun findBy(host: String, withAliases: Boolean = false): Result<List<Emoji>>
 
     suspend fun sync(host: String): Result<Unit>
 
@@ -17,7 +17,7 @@ interface CustomEmojiRepository {
 
     suspend fun deleteEmojis(host: String, emojis: List<Emoji>): Result<Unit>
 
-    fun observeBy(host: String): Flow<List<Emoji>>
+    fun observeBy(host: String, withAliases: Boolean = false): Flow<List<Emoji>>
 
     fun get(host: String): List<Emoji>?
 


### PR DESCRIPTION
## やったこと
一部大規模インスタンスなどでは一つのカスタム絵文字に
aliasを100以上設定していることもあり、メモリを逼迫させる原因にもなっている可能性があったので
aliasが必要でない限りは極力読み込まないようにし、必要になった時だけ使用するようにした。

## 動作確認


## スクリーンショット(任意)


## 備考
絵文字の検索が少し遅くなってしまった

## Issue番号
Closed #1833 


