### PR TITLE
チャンネル画面のFragmentの管理手法を変更しクラッシュしづらくした

### DIFF
--- a/modules/common_compose/src/main/java/net/pantasystem/milktea/common_compose/ComposeAndFragment.kt
+++ b/modules/common_compose/src/main/java/net/pantasystem/milktea/common_compose/ComposeAndFragment.kt
@@ -1,0 +1,35 @@
+package net.pantasystem.milktea.common_compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+
+@Composable
+fun <T : Fragment> rememberFragment(
+    vararg inputs: Any?,
+    fragmentManager: FragmentManager,
+    initial: () -> T,
+): T {
+    return rememberSaveable(
+        inputs = inputs,
+        saver = Saver(
+            save = { fragment ->
+                if (fragment in fragmentManager.fragments) {
+                    fragmentManager
+                        .saveFragmentInstanceState(fragment)
+                } else {
+                    null
+                }
+            },
+            restore = { savedState ->
+                initial().also { fragment ->
+                    fragment.setInitialSavedState(savedState)
+                }
+            },
+        ),
+    ) {
+        initial()
+    }
+}

--- a/modules/features/channel/build.gradle
+++ b/modules/features/channel/build.gradle
@@ -58,7 +58,9 @@ dependencies {
     implementation project(path: ':modules:common_navigation')
     implementation project(path: ':modules:common_android_ui')
     implementation project(path: ':modules:features:note')
+    implementation project(path: ':modules:common_compose')
     implementation project(path: ':modules:common_viewmodel')
+
     testImplementation libs.junit
     androidTestImplementation libs.androidx.test.ext.junit
     androidTestImplementation libs.androidx.test.espresso.core

--- a/modules/features/channel/src/main/java/net/pantasystem/milktea/channel/ChannelActivity.kt
+++ b/modules/features/channel/src/main/java/net/pantasystem/milktea/channel/ChannelActivity.kt
@@ -113,14 +113,14 @@ class ChannelActivity : AppCompatActivity() {
                                     )
                                 )
                             },
-                            onUpdateFragment = { id, layout, channelId ->
-                                val fragment = pageableFragmentFactory.create(
-                                    channelId.accountId,
-                                    Pageable.ChannelTimeline(channelId.channelId)
+                            fragmentManagerProvider = {
+                                supportFragmentManager
+                            },
+                            timelineFragmentProvider = {
+                                pageableFragmentFactory.create(
+                                    viewModel.channelId.accountId,
+                                    Pageable.ChannelTimeline(viewModel.channelId.channelId)
                                 )
-                                val ft = supportFragmentManager.beginTransaction()
-                                ft.replace(id, fragment)
-                                ft.commit()
                             }
                         )
                     }

--- a/modules/features/channel/src/main/java/net/pantasystem/milktea/channel/ChannelDetailScreen.kt
+++ b/modules/features/channel/src/main/java/net/pantasystem/milktea/channel/ChannelDetailScreen.kt
@@ -1,15 +1,31 @@
 package net.pantasystem.milktea.channel
 
-import android.widget.FrameLayout
+import android.view.View
+import android.view.ViewGroup
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.*
+import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentContainerView
+import androidx.fragment.app.FragmentManager
+import net.pantasystem.milktea.common_compose.rememberFragment
 import net.pantasystem.milktea.model.channel.Channel
 
 @Composable
@@ -18,8 +34,22 @@ fun ChannelDetailScreen(
     onNavigateNoteEditor: (Channel.Id) -> Unit,
     channelId: Channel.Id,
     channel: Channel?,
-    onUpdateFragment: (Int, FrameLayout, Channel.Id) -> Unit,
+    fragmentManagerProvider: () -> FragmentManager,
+    timelineFragmentProvider: () -> Fragment,
 ) {
+    var container: FragmentContainerView? by remember {
+        mutableStateOf(null)
+    }
+    val timelineFragment = rememberFragment(fragmentManager = fragmentManagerProvider()) {
+        timelineFragmentProvider()
+    }
+
+    LaunchedEffect(Unit) {
+        fragmentManagerProvider().beginTransaction()
+            .replace(container!!.id , timelineFragment)
+            .commitAllowingStateLoss()
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -43,13 +73,13 @@ fun ChannelDetailScreen(
     ) { paddingValues ->
         AndroidView(
             modifier = Modifier.padding(paddingValues),
-            factory = {
-            FrameLayout(it).apply {
-                id = R.id.container
-            }
-        }, update = {
-            it.id = R.id.container
-            onUpdateFragment(R.id.container, it, channelId)
-        })
+            factory = { context ->
+                FragmentContainerView(context).also { container ->
+                    container.layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+                    container.id = View.generateViewId()
+                }.also {
+                    container = it
+                }
+        },)
     }
 }


### PR DESCRIPTION
## やったこと
Fragmentの管理方法に問題があり、
チャンネル詳細画面のクラッシュが頻発していた。
Fragmentの管理手法を変更することにより、これら問題の軽減を狙いたい。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1851 


