### PR TITLE
カスタム絵文字のダウンロードを長時間ワーカーで実行するようにした

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,6 +64,11 @@
                 android:enabled="true"
                 android:exported="false" />
 
+        <receiver
+            android:name="net.pantasystem.milktea.worker.emoji.cache.CancelCacheCustomEmojiImageWorkerReceiver"
+            android:enabled="true"
+            android:exported="false" />
+
         <meta-data
                 android:name="com.google.firebase.messaging.default_notification_icon"
                 android:resource="@drawable/ic_launcher_foreground" />

--- a/app/src/main/java/jp/panta/misskeyandroidclient/worker/WorkerJobInitializer.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/worker/WorkerJobInitializer.kt
@@ -50,7 +50,7 @@ class WorkerJobInitializer @Inject constructor(
                 SyncMastodonFilterWorker.createPeriodicWorkerRequest(),
             )
             enqueueUniquePeriodicWork(
-                "cacheEmojiImages",
+                CacheCustomEmojiImageWorker.WORKER_NAME,
                 ExistingPeriodicWorkPolicy.REPLACE,
                 CacheCustomEmojiImageWorker.createPeriodicWorkRequest(),
             )

--- a/app/src/main/java/jp/panta/misskeyandroidclient/worker/WorkerJobInitializer.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/worker/WorkerJobInitializer.kt
@@ -51,7 +51,7 @@ class WorkerJobInitializer @Inject constructor(
             )
             enqueueUniquePeriodicWork(
                 CacheCustomEmojiImageWorker.WORKER_NAME,
-                ExistingPeriodicWorkPolicy.REPLACE,
+                ExistingPeriodicWorkPolicy.KEEP,
                 CacheCustomEmojiImageWorker.createPeriodicWorkRequest(),
             )
 

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -623,6 +623,7 @@
     <string name="qr_code">QRコード</string>
     <string name="copy">コピー</string>
     <string name="no_app_available_to_open_this_file">このファイルを開くアプリがありません</string>
+    <string name="notification_sync_download_custom_emoji_title">カスタム絵文字ダウンロード中</string>
     <!-- User -->
 
 

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -614,6 +614,7 @@
     <string name="qr_code">QR Code</string>
     <string name="copy">Copy</string>
     <string name="no_app_available_to_open_this_file">没有应用可打开此文件</string>
+    <string name="notification_sync_download_custom_emoji_title">下载自定义表情符号</string>
     <!-- User -->
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -622,6 +622,7 @@
     <string name="qr_code">QR Code</string>
     <string name="copy">Copy</string>
     <string name="no_app_available_to_open_this_file">No app available to open this file</string>
+    <string name="notification_sync_download_custom_emoji_title">Downloading custom emoji</string>
     <!-- reaction-acceptance -->
 
 </resources>

--- a/modules/worker/src/main/java/net/pantasystem/milktea/worker/emoji/cache/CacheCustomEmojiImageWorker.kt
+++ b/modules/worker/src/main/java/net/pantasystem/milktea/worker/emoji/cache/CacheCustomEmojiImageWorker.kt
@@ -1,9 +1,15 @@
 package net.pantasystem.milktea.worker.emoji.cache
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.core.app.NotificationCompat
 import androidx.hilt.work.HiltWorker
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
 import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequest
 import androidx.work.PeriodicWorkRequestBuilder
@@ -18,6 +24,7 @@ import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.emoji.CustomEmojiRepository
 import net.pantasystem.milktea.model.emoji.SaveCustomEmojiImageUseCase
 import net.pantasystem.milktea.model.image.ImageCacheRepository
+import net.pantasystem.milktea.worker.R
 import java.util.concurrent.TimeUnit
 
 @HiltWorker
@@ -32,6 +39,8 @@ class CacheCustomEmojiImageWorker @AssistedInject constructor(
 ) : CoroutineWorker(context, params) {
 
     companion object {
+        const val NOTIFICATION_CHANNEL_ID = "CACHE_CUSTOM_EMOJI_IMAGE_WORKER"
+
         fun createPeriodicWorkRequest(): PeriodicWorkRequest {
             val constraints = Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.UNMETERED) // Wi-Fi (or Ethernet etc) required
@@ -49,6 +58,7 @@ class CacheCustomEmojiImageWorker @AssistedInject constructor(
 
     override suspend fun doWork(): Result {
         try {
+            setForeground(createForegroundInfo())
             val hosts = accountRepository.findAll().getOrThrow().map {
                 it.getHost()
             }.distinct()
@@ -82,5 +92,38 @@ class CacheCustomEmojiImageWorker @AssistedInject constructor(
             return Result.failure()
         }
     }
+
+    private fun createForegroundInfo(): ForegroundInfo {
+        val title = applicationContext.getString(R.string.notification_sync_download_custom_emoji_title)
+
+        // Create a Notification channel if necessary
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            createChannel()
+        }
+
+        val notification = NotificationCompat.Builder(applicationContext, NOTIFICATION_CHANNEL_ID)
+            .setContentTitle(title)
+            .setTicker(title)
+            .setSmallIcon(android.R.drawable.stat_sys_download)
+            .setOngoing(true)
+            .addAction(android.R.drawable.ic_delete, applicationContext.getString(android.R.string.cancel), null)
+            .build()
+
+        return ForegroundInfo(7, notification)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun createChannel() {
+        val notificationManager =
+            applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        // Create a Notification channel
+        if (notificationManager.getNotificationChannel(NOTIFICATION_CHANNEL_ID) == null) {
+            val channel =
+                NotificationChannel(NOTIFICATION_CHANNEL_ID, "Custom emoji download notification", NotificationManager.IMPORTANCE_HIGH)
+            channel.description = "Notification representing custom emoji download"
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+
 
 }

--- a/modules/worker/src/main/java/net/pantasystem/milktea/worker/emoji/cache/CacheCustomEmojiImageWorker.kt
+++ b/modules/worker/src/main/java/net/pantasystem/milktea/worker/emoji/cache/CacheCustomEmojiImageWorker.kt
@@ -49,7 +49,7 @@ class CacheCustomEmojiImageWorker @AssistedInject constructor(
                 .setRequiredNetworkType(NetworkType.UNMETERED) // Wi-Fi (or Ethernet etc) required
                 .build()
 
-            return PeriodicWorkRequestBuilder<CacheCustomEmojiImageWorker>(15, TimeUnit.MINUTES)
+            return PeriodicWorkRequestBuilder<CacheCustomEmojiImageWorker>(1, TimeUnit.DAYS)
                 .setConstraints(constraints)
                 .build()
         }

--- a/modules/worker/src/main/java/net/pantasystem/milktea/worker/emoji/cache/CancelCacheCustomEmojiImageWorkerReceiver.kt
+++ b/modules/worker/src/main/java/net/pantasystem/milktea/worker/emoji/cache/CancelCacheCustomEmojiImageWorkerReceiver.kt
@@ -1,0 +1,13 @@
+package net.pantasystem.milktea.worker.emoji.cache
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.work.WorkManager
+
+class CancelCacheCustomEmojiImageWorkerReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+        context ?: return
+        WorkManager.getInstance(context).cancelUniqueWork(CacheCustomEmojiImageWorker.WORKER_NAME)
+    }
+}


### PR DESCRIPTION
## やったこと
カスタム絵文字のダウンロードを長時間ワーカーで実行できるようにし、
かつバックグラウンド処理の通知にキャンセルアクションを追加し、
キャンセルアクション経由でダウンロードをキャンセルできるようにした。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1854 



