### PR TITLE
現在の投票数を画面に表示させるようにした

### DIFF
--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -112,6 +112,7 @@
     <string name="reacted_by">%sさんにリアクションされました</string>
     <string name="renoted_by">%sさんにリノートされました</string>
     <string name="follow_requested_by">%sさんにフォローリクエストされました。</string>
+    <string name="total_vote_count">計%s票</string>
     <string name="poll_ended">投票が終了</string>
 
     <string name="input_message">相手に思いを伝えてください</string>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -110,6 +110,7 @@
     <string name="renoted_by">被 %s 转帖</string>
     <string name="follow_requested_by">来自 %s 的关注请求</string>
     <string name="poll_ended">投票结束</string>
+    <string name="total_vote_count">总票数 %s</string>
 
     <string name="input_message">有什么新鲜事?</string>
 

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -107,6 +107,7 @@
     <string name="replied_by">Reply from %s</string>
     <string name="quoted_by">Quoted by %s</string>
     <string name="voted_by">poll voted in by %s</string>
+    <string name="total_vote_count">%s votes in total</string>
     <string name="mention_by">mentioned by %s</string>
     <string name="reacted_by">reaction sent by %s</string>
     <string name="renoted_by">renoted by %s</string>

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/poll/PollHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/poll/PollHelper.kt
@@ -19,5 +19,6 @@ object PollHelper {
             this.visibility = View.VISIBLE
         }
         PollListLinearLayoutBinder.bindPollChoices(this, noteId, poll, noteCardActionListenerAdapter)
+        PollListLinearLayoutBinder.bindVoteResult(this, poll.totalVoteCount)
     }
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/poll/PollListLinearLayoutBinder.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/poll/PollListLinearLayoutBinder.kt
@@ -4,7 +4,9 @@ import android.view.LayoutInflater
 import android.widget.LinearLayout
 import net.pantasystem.milktea.model.note.Note
 import net.pantasystem.milktea.model.note.poll.Poll
+import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.databinding.ItemChoiceBinding
+import net.pantasystem.milktea.note.databinding.ItemVoteResultBinding
 import net.pantasystem.milktea.note.view.NoteCardActionListenerAdapter
 
 object PollListLinearLayoutBinder {
@@ -37,16 +39,32 @@ object PollListLinearLayoutBinder {
         }
     }
 
-    private fun bindItem(binding: ItemChoiceBinding, choice: Poll.Choice, noteId: Note.Id, poll: Poll, onVoteSelected: (OnVoted) -> Unit) {
-        binding.radioChoice.setOnClickListener {
-            onVoteSelected(OnVoted(noteId, choice, poll))
-        }
+    fun bindVoteResult(
+        layout: LinearLayout,
+        totalVoteCount: Int
+    ) {
+        val binding = ItemVoteResultBinding.inflate(LayoutInflater.from(layout.context), layout, false)
 
-        binding.radioChoice.text = choice.text
-        binding.radioChoice.isEnabled = poll.canVote
-        binding.radioChoice.isChecked = choice.isVoted
-
-        binding.progressBar.max = poll.totalVoteCount
-        binding.progressBar.progress = choice.votes
+        binding.voteResult.text = layout.context.getString(R.string.total_vote_count, totalVoteCount.toString())
+        layout.addView(binding.root)
     }
+}
+
+private fun bindItem(
+    binding: ItemChoiceBinding,
+    choice: Poll.Choice,
+    noteId: Note.Id,
+    poll: Poll,
+    onVoteSelected: (OnVoted) -> Unit
+) {
+    binding.radioChoice.setOnClickListener {
+        onVoteSelected(OnVoted(noteId, choice, poll))
+    }
+
+    binding.radioChoice.text = choice.text
+    binding.radioChoice.isEnabled = poll.canVote
+    binding.radioChoice.isChecked = choice.isVoted
+
+    binding.progressBar.max = poll.totalVoteCount
+    binding.progressBar.progress = choice.votes
 }

--- a/modules/features/note/src/main/res/layout/item_vote_result.xml
+++ b/modules/features/note/src/main/res/layout/item_vote_result.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/voteResult"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/modules/features/note/src/main/res/layout/item_vote_result.xml
+++ b/modules/features/note/src/main/res/layout/item_vote_result.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <TextView
-        android:id="@+id/voteResult"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+<TextView android:id="@+id/voteResult"
+    android:layout_height="wrap_content"
+    android:layout_width="wrap_content"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    />


### PR DESCRIPTION
## やったこと
web版misskeyのように、現在の投票数を画面に表示させるようにした。
位置は一番下の選択肢の真下(スクリーンショット参照)。

## 動作確認
<image src="https://github.com/pantasystem/Milktea/assets/62137820/df85ed56-da30-4076-8df8-8eec375d3251" width="500px"></image>

## スクリーンショット(任意)
en | zh
:--: | :--:
<img width="300" alt="image" src="https://github.com/pantasystem/Milktea/assets/62137820/4fbe929c-7f22-4d72-b3c7-6dd57a9423fd"> | <img width="300" alt="image" src="https://github.com/pantasystem/Milktea/assets/62137820/28989ee2-f30e-460a-a054-7d6e469120fa">



## 備考


## Issue番号
Close #1842 


