### PR TITLE
投稿画面のファイル選択ボタンを変更した

### DIFF
--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorUserActionMenuLayout.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorUserActionMenuLayout.kt
@@ -84,7 +84,7 @@ fun NoteEditorUserActionMenuLayout(
                 }
             ) {
                 Icon(
-                    Icons.Default.AddToPhotos,
+                    Icons.Default.AttachFile,
                     contentDescription = null,
                     tint = iconColor
                 )


### PR DESCRIPTION
## やったこと
ファイルの選択ボタンとして若干認識しづらかった投稿画面のファイル選択ボタンを変更した

## 動作確認
## スクリーンショット(任意)
Before | After
:--: | :--:
<img src="https://github.com/pantasystem/Milktea/assets/62137820/775d1107-39cb-41c4-bff8-cf30f3841383" width="800" /> | <img src="https://github.com/pantasystem/Milktea/assets/62137820/a10dea02-79ce-4033-b064-907904b4d688" width="800" />


## 備考


## Issue番号
Close #1682 

