### PR TITLE
自分の投稿には報告の選択肢を表示しないようにした

### DIFF
--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialogLayout.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialogLayout.kt
@@ -203,8 +203,8 @@ fun NoteOptionDialogLayout(
                     text = stringResource(id = R.string.remove_note)
                 )
             }
-            Divider()
             if (!uiState.isMyNote) {
+                Divider()
                 NormalBottomSheetDialogSelectionLayout(
                     onClick = {
                         onReportButtonClicked(uiState.noteRelation)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialogLayout.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialogLayout.kt
@@ -204,13 +204,15 @@ fun NoteOptionDialogLayout(
                 )
             }
             Divider()
-            NormalBottomSheetDialogSelectionLayout(
-                onClick = {
-                    onReportButtonClicked(uiState.noteRelation)
-                },
-                icon = Icons.Default.Report,
-                text = stringResource(id = R.string.report)
-            )
+            if (!uiState.isMyNote) {
+                NormalBottomSheetDialogSelectionLayout(
+                    onClick = {
+                        onReportButtonClicked(uiState.noteRelation)
+                    },
+                    icon = Icons.Default.Report,
+                    text = stringResource(id = R.string.report)
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## やったこと
自分の投稿を報告できる仕組みは必要ないので、自分の投稿には「報告」の選択肢を表示しないようにした

## 動作確認
以下、自分の投稿のスクリーンショット
Before | After
:--: | :--:
<image src="https://github.com/pantasystem/Milktea/assets/62137820/e0976b3e-8ff1-40ce-bac7-2f37a07473db" width="400"></image> | <image src="https://github.com/pantasystem/Milktea/assets/62137820/913ba224-8c9b-4590-8861-c32d34332302" width="400"></image>

## スクリーンショット(任意)
他者の投稿にはきちんと報告が残っている
<image src="https://github.com/pantasystem/Milktea/assets/62137820/b61135a9-0a87-4c90-a856-d8935ad90f7c" width="400"/>


## 備考


## Issue番号
Close #1869 


