### PR TITLE
フォローおよびフォロワーの一覧画面をグリッド表示化した

### DIFF
--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/compose/UserDetailCardPageableList.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/compose/UserDetailCardPageableList.kt
@@ -1,8 +1,10 @@
 package net.pantasystem.milktea.user.compose
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -13,6 +15,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
+import androidx.compose.ui.unit.dp
 import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -42,7 +45,7 @@ fun UserDetailCardPageableList(
     myId: String?,
     onAction: (UserDetailCardPageableListAction) -> Unit,
 ) {
-    val scrollController = rememberLazyListState()
+    val scrollController = rememberLazyGridState()
     LaunchedEffect(key1 = null) {
         snapshotFlow {
             scrollController.isScrolledToTheEnd()
@@ -62,7 +65,7 @@ fun UserDetailCardPageableList(
                     .nestedScroll(rememberNestedScrollInteropConnection())
                     .fillMaxSize()
             ) {
-                LazyColumn(modifier = Modifier.fillMaxSize(), state = scrollController) {
+                LazyVerticalGrid(columns = GridCells.Adaptive(minSize = 351.dp), state = scrollController) {
                     items(count = users.size) { i ->
                         UserDetailCard(
                             userDetail = users[i],
@@ -74,7 +77,7 @@ fun UserDetailCardPageableList(
                             myId = myId,
                         )
                     }
-                    item {
+                    item(span = { GridItemSpan(maxLineSpan) }){
                         Row(
                             Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.Center,

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/compose/UserDetailCardPageableList.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/compose/UserDetailCardPageableList.kt
@@ -65,7 +65,7 @@ fun UserDetailCardPageableList(
                     .nestedScroll(rememberNestedScrollInteropConnection())
                     .fillMaxSize()
             ) {
-                LazyVerticalGrid(columns = GridCells.Adaptive(minSize = 351.dp), state = scrollController) {
+                LazyVerticalGrid(columns = GridCells.Adaptive(minSize = 350.dp), state = scrollController) {
                     items(count = users.size) { i ->
                         UserDetailCard(
                             userDetail = users[i],
@@ -80,7 +80,7 @@ fun UserDetailCardPageableList(
                     item(span = { GridItemSpan(maxLineSpan) }){
                         Row(
                             Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.Center,
+                            horizontalArrangement = Arrangement.Center
                         ) {
                             CircularProgressIndicator()
                         }


### PR DESCRIPTION
## やったこと
フォローおよびフォロワー一覧画面を、デバイスの幅に合わせてグリッド表示させるようにした

## 動作確認
\ | 縦表示 | 横表示
:--: | :--: | :--:
360dp×680dp(700dpから2列になる) |<video src="https://github.com/pantasystem/Milktea/assets/62137820/92251adf-92b7-48ba-ad77-7d461554cfc6" width="30" height="30"></video>| <video src="https://github.com/pantasystem/Milktea/assets/62137820/71327048-f51e-4c77-a340-186f3041f30f" width="30" height="30"></video>  |
Pixel6a(412dp×915dp) |<video src="https://github.com/pantasystem/Milktea/assets/62137820/86b99a15-8714-43aa-a781-e96e51baf8a6" width="30" height="30"></video>| <video src="https://github.com/pantasystem/Milktea/assets/62137820/a51222c5-a86a-4369-8531-4ed6ab3b5d18" width="30" height="30"></video>|
PixelFold(842dp×701dp) |<video src="https://github.com/pantasystem/Milktea/assets/62137820/e7f41c6f-2335-4d3e-bde5-0356ab83ef09" width="30" height="30"></video>| 縦表示と同様に２列
|PixelTablet(1280dp×800dp) |<video src="https://github.com/pantasystem/Milktea/assets/62137820/51c6d34f-eda8-422f-8147-51fd79eac6ac" width="30" height="30"></video>| <video src="https://github.com/pantasystem/Milktea/assets/62137820/613f8c78-7d52-46ed-90a0-c556fffb50b3" width="30" height="30"></video> 

## 備考
- pixelFoldは、閉じたときPixel6aと同じで縦の時1列、横の時2列

## Issue番号
Close #1872 


