### PR TITLE
mastodonでもユーザリストを作成できるようにした

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
@@ -12,6 +12,7 @@ import net.pantasystem.milktea.api.mastodon.emojis.TootEmojiDTO
 import net.pantasystem.milktea.api.mastodon.filter.V1FilterDTO
 import net.pantasystem.milktea.api.mastodon.instance.Instance
 import net.pantasystem.milktea.api.mastodon.list.AddAccountsToList
+import net.pantasystem.milktea.api.mastodon.list.CreateListRequest
 import net.pantasystem.milktea.api.mastodon.list.ListDTO
 import net.pantasystem.milktea.api.mastodon.list.RemoveAccountsFromList
 import net.pantasystem.milktea.api.mastodon.marker.MarkersDTO
@@ -242,6 +243,9 @@ interface MastodonAPI {
 
     @GET("api/v1/lists")
     suspend fun getMyLists(): Response<List<ListDTO>>
+
+    @POST("api/v1/lists")
+    suspend fun createList(@Body body: CreateListRequest): Response<ListDTO>
 
     @GET("api/v1/lists/{listId}")
     suspend fun getList(@Path("listId") listId: String): Response<ListDTO>

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/list/CreateListRequest.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/list/CreateListRequest.kt
@@ -1,0 +1,10 @@
+package net.pantasystem.milktea.api.mastodon.list
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CreateListRequest(
+    @SerialName("title") val title: String,
+    @SerialName("replies_policy") val repliesPolicy: ListDTO.RepliesPolicyType
+)


### PR DESCRIPTION
## やったこと
Mastodonでもユーザリストを作成できるようにしました。

## 動作確認
エミューレーターで実際にユーザリストを作成できることを確認しました

## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1878 


