### PR TITLE
リノート時にアイコンの右下にインスタンスの画像を設置した

### DIFF
--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenoteBottomSheetDialog.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenoteBottomSheetDialog.kt
@@ -71,13 +71,8 @@ class RenoteBottomSheetDialog : BottomSheetDialogFragment() {
                 MilkteaStyleConfigApplyAndTheme(configRepository = configRepository) {
                     val uiState by viewModel.uiState.collectAsState()
 
-                    val accountIdToIconUrlMap = uiState.accounts.map {
-                        it.accountId to (it.instanceIconUrl ?: "")
-                    }.toMap()
-
                     RenoteDialogContent(
                         uiState = uiState,
-                        accountIdToIconUrlMap = accountIdToIconUrlMap,
                         isRenotedByMe = isRenotedByMe,
                         onToggleAddAccount = {
                             viewModel.toggleAddAccount(it)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenoteBottomSheetDialog.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenoteBottomSheetDialog.kt
@@ -70,8 +70,14 @@ class RenoteBottomSheetDialog : BottomSheetDialogFragment() {
             setContent {
                 MilkteaStyleConfigApplyAndTheme(configRepository = configRepository) {
                     val uiState by viewModel.uiState.collectAsState()
+
+                    val accountIdToIconUrlMap = uiState.accounts.map {
+                        it.accountId to (it.instanceIconUrl ?: "")
+                    }.toMap()
+
                     RenoteDialogContent(
                         uiState = uiState,
+                        accountIdToIconUrlMap = accountIdToIconUrlMap,
                         isRenotedByMe = isRenotedByMe,
                         onToggleAddAccount = {
                             viewModel.toggleAddAccount(it)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenoteDialogLayout.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenoteDialogLayout.kt
@@ -15,6 +15,7 @@ import net.pantasystem.milktea.note.view.NormalBottomSheetDialogSelectionLayout
 @Composable
 fun RenoteDialogContent(
     uiState: RenoteViewModelUiState,
+    accountIdToIconUrlMap: Map<Long, String>,
     isRenotedByMe: Boolean,
     onToggleAddAccount: (Long) -> Unit,
     onRenoteButtonClicked: () -> Unit,
@@ -29,7 +30,11 @@ fun RenoteDialogContent(
                 .fillMaxWidth()
                 .padding(vertical = 8.dp)
         ) {
-            RenoteTargetAccountRowList(accounts = uiState.accounts, onClick = onToggleAddAccount)
+            RenoteTargetAccountRowList(
+                accounts = uiState.accounts,
+                accountIdToIconUrlMap = accountIdToIconUrlMap,
+                onClick = onToggleAddAccount
+            )
             NormalBottomSheetDialogSelectionLayout(
                 onClick = onRenoteButtonClicked,
                 icon = Icons.Default.Repeat,

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenoteDialogLayout.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenoteDialogLayout.kt
@@ -15,7 +15,6 @@ import net.pantasystem.milktea.note.view.NormalBottomSheetDialogSelectionLayout
 @Composable
 fun RenoteDialogContent(
     uiState: RenoteViewModelUiState,
-    accountIdToIconUrlMap: Map<Long, String>,
     isRenotedByMe: Boolean,
     onToggleAddAccount: (Long) -> Unit,
     onRenoteButtonClicked: () -> Unit,
@@ -32,7 +31,6 @@ fun RenoteDialogContent(
         ) {
             RenoteTargetAccountRowList(
                 accounts = uiState.accounts,
-                accountIdToIconUrlMap = accountIdToIconUrlMap,
                 onClick = onToggleAddAccount
             )
             NormalBottomSheetDialogSelectionLayout(

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenoteTargetAccountList.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenoteTargetAccountList.kt
@@ -1,5 +1,6 @@
 package net.pantasystem.milktea.note.renote
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
@@ -7,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -19,9 +21,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil.compose.rememberAsyncImagePainter
 import net.pantasystem.milktea.common_compose.AvatarIcon
 import net.pantasystem.milktea.common_compose.CustomEmojiText
 import net.pantasystem.milktea.model.emoji.Emoji
@@ -30,6 +34,7 @@ import net.pantasystem.milktea.model.emoji.Emoji
 fun RenoteTargetAccountRowList(
     modifier: Modifier = Modifier,
     accounts: List<AccountInfo>,
+    accountIdToIconUrlMap: Map<Long, String>,
     onClick: (Long) -> Unit,
 ) {
     Row(
@@ -49,6 +54,7 @@ fun RenoteTargetAccountRowList(
                 emojis = it.user.emojis,
                 isEnable = it.isEnable,
                 accountHost = it.user.host,
+                iconUrl = accountIdToIconUrlMap[it.accountId]!!
             )
         }
     }
@@ -63,6 +69,7 @@ fun SelectableAvatarOnlyAccount(
     avatarUrl: String,
     emojis: List<Emoji>,
     accountHost: String?,
+    iconUrl: String,
     onClick: () -> Unit,
 ) {
     Column(
@@ -106,9 +113,23 @@ fun SelectableAvatarOnlyAccount(
                 }
             }
 
-
+            Image(
+                painter = rememberAsyncImagePainter(iconUrl),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = modifier
+                    .size(12.dp)
+                    .align(Alignment.BottomEnd)
+            )
         }
-        CustomEmojiText(text = username, emojis = emojis, maxLines = 1, fontSize = 8.sp, accountHost = accountHost, sourceHost = accountHost)
+        CustomEmojiText(
+            text = username,
+            emojis = emojis,
+            maxLines = 1,
+            fontSize = 8.sp,
+            accountHost = accountHost,
+            sourceHost = accountHost
+        )
     }
 
 }
@@ -123,6 +144,7 @@ fun PreviewSelectableAvatarOnlyAccount() {
         username = "@harunon",
         emojis = emptyList(),
         isEnable = true,
-        accountHost = "misskey.io"
+        accountHost = "misskey.io",
+        iconUrl = ""
     )
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenoteTargetAccountList.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenoteTargetAccountList.kt
@@ -34,7 +34,6 @@ import net.pantasystem.milktea.model.emoji.Emoji
 fun RenoteTargetAccountRowList(
     modifier: Modifier = Modifier,
     accounts: List<AccountInfo>,
-    accountIdToIconUrlMap: Map<Long, String>,
     onClick: (Long) -> Unit,
 ) {
     Row(
@@ -54,7 +53,7 @@ fun RenoteTargetAccountRowList(
                 emojis = it.user.emojis,
                 isEnable = it.isEnable,
                 accountHost = it.user.host,
-                iconUrl = accountIdToIconUrlMap[it.accountId]!!
+                iconUrl = it.instanceIconUrl ?: ""
             )
         }
     }


### PR DESCRIPTION
## やったこと
- リノート時にアイコンの右下にインスタンスの画像を設置した
- `AccountViewModel`を使わないように修正した
  - https://github.com/pantasystem/Milktea/pull/1880#issuecomment-1725548008

## Issue番号
Close #1447


