### PR TITLE
チャンネル詳細画面のヘッダーの戻るボタンが正常に動作するようにした

### DIFF
--- a/modules/features/channel/src/main/java/net/pantasystem/milktea/channel/ChannelActivity.kt
+++ b/modules/features/channel/src/main/java/net/pantasystem/milktea/channel/ChannelActivity.kt
@@ -99,7 +99,7 @@ class ChannelActivity : AppCompatActivity() {
                         val viewModel: ChannelDetailViewModel = hiltViewModel()
                         val channel by viewModel.channel.collectAsState()
                         ChannelDetailScreen(
-                            onNavigateUp = { navController.popBackStack() },
+                            onNavigateUp = { if(!navController.popBackStack()) finish() },
                             channelId = viewModel.channelId,
                             channel = channel,
                             onNavigateNoteEditor = {


### PR DESCRIPTION
## やったこと
チャンネル一覧以外からチャンネル詳細画面に入った時に動作しなかったヘッダーの戻るボタンを修正した
- 戻るボタンを押したときにもともといた画面へ戻るようにした
    - チャンネル一覧画面から詳細画面に入った時に戻るボタンを押すと今まで通り一覧画面へ戻る

## 動作確認
1. チャンネル一覧以外からチャンネル詳細画面へ入った時

https://github.com/pantasystem/Milktea/assets/62137820/a897864a-148f-487f-bd5a-35fef2c607f4


2. チャンネル一覧からチャンネル詳細画面へ入った時

https://github.com/pantasystem/Milktea/assets/62137820/eb34395d-eaf3-4f04-8c80-9adee09e90ed


## 備考
- ここを参考にしました。
https://developer.android.com/guide/navigation/backstack?hl=ja#handle-failure

## Issue番号
Close #1885 


