### PR TITLE
タブに追加機能を持つすべてのアイコンを共通化

### DIFF
--- a/modules/common_resource/src/main/res/menu/note_detail_menu.xml
+++ b/modules/common_resource/src/main/res/menu/note_detail_menu.xml
@@ -11,7 +11,7 @@
     <item
             android:id="@+id/nav_add_to_tab"
             android:title="@string/add_to_tab"
-            android:icon="@drawable/ic_add_black_24dp"
+            android:icon="@drawable/ic_add_to_tab_24px"
             app:showAsAction="ifRoom"
             />
 </menu>

--- a/modules/features/channel/src/main/java/net/pantasystem/milktea/channel/ChannelCard.kt
+++ b/modules/features/channel/src/main/java/net/pantasystem/milktea/channel/ChannelCard.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
-import androidx.compose.material.icons.filled.BookmarkAdd
-import androidx.compose.material.icons.filled.BookmarkRemove
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
@@ -17,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -84,13 +83,13 @@ private fun AddToTabButton(isPaged: Boolean, onPressed: () -> Unit) {
     IconButton(onClick = onPressed) {
         if (isPaged) {
             Icon(
-                imageVector = Icons.Default.BookmarkRemove,
+                painter = painterResource(R.drawable.ic_remove_to_tab_24px),
                 contentDescription = "add to tab",
                 tint = MaterialTheme.colors.secondary
             )
         } else {
             Icon(
-                imageVector = Icons.Default.BookmarkAdd,
+                painter = painterResource(R.drawable.ic_add_to_tab_24px),
                 contentDescription = "add to tab",
                 tint = MaterialTheme.colors.secondary
             )

--- a/modules/features/clip/src/main/java/net/pantasystem/milktea/clip/ClipTile.kt
+++ b/modules/features/clip/src/main/java/net/pantasystem/milktea/clip/ClipTile.kt
@@ -6,13 +6,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.*
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.BookmarkAdd
-import androidx.compose.material.icons.filled.BookmarkRemove
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import net.pantasystem.milktea.common_compose.CircleCheckbox
@@ -62,13 +60,13 @@ private fun AddToTabButton(isPaged: Boolean, onPressed: () -> Unit) {
     IconButton(onClick = onPressed) {
         if (isPaged) {
             Icon(
-                imageVector = Icons.Default.BookmarkRemove,
+                painter = painterResource(R.drawable.ic_remove_to_tab_24px),
                 contentDescription = "add to tab",
                 tint = MaterialTheme.colors.secondary
             )
         } else {
             Icon(
-                imageVector = Icons.Default.BookmarkAdd,
+                painter = painterResource(R.drawable.ic_add_to_tab_24px),
                 contentDescription = "add to tab",
                 tint = MaterialTheme.colors.secondary
             )

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/compose/tab/TabItemsListScreen.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/compose/tab/TabItemsListScreen.kt
@@ -5,10 +5,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.BookmarkAdd
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import kotlinx.coroutines.launch
 import net.pantasystem.milktea.model.account.page.Page
@@ -72,7 +72,7 @@ internal fun TabItemsListScreen(
                         Text(stringResource(R.string.add_tab))
                     },
                     icon = {
-                        Icon(Icons.Default.BookmarkAdd, contentDescription = null)
+                        Icon(painter = painterResource(R.drawable.ic_add_to_tab_24px), contentDescription = null)
                     },
                     onClick = {
                         scope.launch {

--- a/modules/features/userlist/src/main/java/net/pantasystem/milktea/userlist/compose/UserListCard.kt
+++ b/modules/features/userlist/src/main/java/net/pantasystem/milktea/userlist/compose/UserListCard.kt
@@ -2,13 +2,11 @@ package net.pantasystem.milktea.userlist.compose
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.BookmarkAdd
-import androidx.compose.material.icons.filled.BookmarkRemove
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -18,6 +16,7 @@ import net.pantasystem.milktea.model.list.UserList
 import net.pantasystem.milktea.model.list.UserListMember
 import net.pantasystem.milktea.model.list.UserListWithMembers
 import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.userlist.R
 import net.pantasystem.milktea.userlist.viewmodel.UserListBindingModel
 
 
@@ -100,13 +99,13 @@ private fun AddToTabButton(modifier: Modifier = Modifier, isPaged: Boolean, onPr
     IconButton(onClick = onPressed, modifier = modifier) {
         if (isPaged) {
             Icon(
-                imageVector = Icons.Default.BookmarkRemove,
+                painter = painterResource(R.drawable.ic_remove_to_tab_24px),
                 contentDescription = "add to tab",
                 tint = MaterialTheme.colors.secondary
             )
         } else {
             Icon(
-                imageVector = Icons.Default.BookmarkAdd,
+                painter = painterResource(R.drawable.ic_add_to_tab_24px),
                 contentDescription = "add to tab",
                 tint = MaterialTheme.colors.secondary
             )

--- a/modules/features/userlist/src/main/java/net/pantasystem/milktea/userlist/compose/UserListDetailScreen.kt
+++ b/modules/features/userlist/src/main/java/net/pantasystem/milktea/userlist/compose/UserListDetailScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.icons.filled.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -76,12 +77,12 @@ fun UserListDetailScreen(
                         IconButton(onClick = onToggleButtonClicked) {
                             if (isAddedTab) {
                                 Icon(
-                                    Icons.Default.BookmarkRemove,
+                                    painter = painterResource(R.drawable.ic_remove_to_tab_24px),
                                     contentDescription = null
                                 )
                             } else {
                                 Icon(
-                                    Icons.Default.BookmarkAdd,
+                                    painter = painterResource(R.drawable.ic_add_to_tab_24px),
                                     contentDescription = null
                                 )
                             }


### PR DESCRIPTION
## やったこと
「タブに追加」機能を持つボタンのアイコンが機能ごとにバラけていたので統一しました
修正した箇所
- リスト一覧画面
- リスト詳細画面
- チャンネル一覧画面
- 「タブを追加する」ボタン
- ノート詳細画面のヘッダー
- クリップ

## スクリーンショット(任意)
/|Before | After
:--:|:--: | :--:
|リスト一覧画面|![image](https://github.com/pantasystem/Milktea/assets/62137820/9af983ee-bf2b-4d46-be26-5503df30a714)|![image](https://github.com/pantasystem/Milktea/assets/62137820/eb74863b-d90e-4862-9eb5-ab2b4621e307)|
リスト詳細画面|![image](https://github.com/pantasystem/Milktea/assets/62137820/f9b81561-0f34-4be2-9540-23ac0a1844ab)|![image](https://github.com/pantasystem/Milktea/assets/62137820/3f2fc582-9d17-466c-8ca3-2735c2a8cabd)|
チャンネル一覧画面|![image](https://github.com/pantasystem/Milktea/assets/62137820/4cf12c90-5f8b-49ca-a729-b3d1bd89ccca)|![image](https://github.com/pantasystem/Milktea/assets/62137820/7b2cce11-4c3a-467d-98b5-4a7cfebbe3eb)|
"タブを追加する"ボタン|![image](https://github.com/pantasystem/Milktea/assets/62137820/dbaf8444-bc99-4403-b341-4c4603003430)|![image](https://github.com/pantasystem/Milktea/assets/62137820/5a59ed58-819a-4991-b530-745e40df53fb)|
ノート詳細画面|![image](https://github.com/pantasystem/Milktea/assets/62137820/8d30e906-71b2-4b88-b955-597e795dc380)|![image](https://github.com/pantasystem/Milktea/assets/62137820/23d1a528-460e-43d6-abaa-5a6cb73a3665)|
クリップ|![image](https://github.com/pantasystem/Milktea/assets/62137820/bc8f4609-98db-4d93-9da3-c8f8a0a1d15c)|![image](https://github.com/pantasystem/Milktea/assets/62137820/69656f1b-75af-4e89-b2ce-4091aee292c1)


## 備考
クリップをタブに追加する機能は未実装？

## Issue番号
Close #1545 


