### PR TITLE
チャンネル一覧画面のChannelCardをグリッド表示させた

### DIFF
--- a/modules/features/channel/src/main/java/net/pantasystem/milktea/channel/ChannelListStatePage.kt
+++ b/modules/features/channel/src/main/java/net/pantasystem/milktea/channel/ChannelListStatePage.kt
@@ -1,7 +1,9 @@
 package net.pantasystem.milktea.channel
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -16,6 +18,7 @@ import net.pantasystem.milktea.common.StateContent
 import net.pantasystem.milktea.data.infrastructure.channel.ChannelListType
 import net.pantasystem.milktea.model.channel.Channel
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ChannelListStateScreen(
     uiState: ChannelListUiState,
@@ -41,7 +44,10 @@ fun ChannelListStateScreen(
         modifier = Modifier
             .fillMaxSize()
     ) {
-        LazyColumn(Modifier.fillMaxSize()) {
+        LazyVerticalStaggeredGrid(
+            columns = StaggeredGridCells.Adaptive(350.dp),
+            modifier = Modifier.fillMaxSize(),
+        ) {
             when (val content = pagingState.content) {
                 is StateContent.Exist -> {
                     items(content.rawContent.size) { index ->
@@ -101,7 +107,9 @@ fun ChannelListStateScreen(
 fun ReachedElement() {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.padding(16.dp).fillMaxWidth()
+        modifier = Modifier
+            .padding(16.dp)
+            .fillMaxWidth()
     ) {
         CircularProgressIndicator()
     }


### PR DESCRIPTION
## やったこと
画面幅が広がっても1列表示だったチャンネル一覧画面を、画面幅によってアダプティブにグリッド表示させるようにした

## 動作確認
\ | 縦表示 | 横表示
:--: | :--: | :--:
Pixel6a(412dp×915dp) |<video src="https://github.com/pantasystem/Milktea/assets/62137820/f82783f3-4a4b-43ec-a935-521204f4fd23" width="30" height="30"></video>| <video src="https://github.com/pantasystem/Milktea/assets/62137820/28983908-fa96-4307-aa0b-3d8ca6178ec7" width="30" height="30"></video>|
PixelFold(842dp×701dp) |<video src="https://github.com/pantasystem/Milktea/assets/62137820/8f1033ad-9004-406f-93ad-7add9ba0e8ab" width="30" height="30"></video>| 縦表示と同様に２列
|PixelTablet(1280dp×800dp) |<video src="https://github.com/pantasystem/Milktea/assets/62137820/1430bc7e-417e-4e02-9bbd-b2216922ff76" width="30" height="30"></video>| <video src="https://github.com/pantasystem/Milktea/assets/62137820/d70e40f1-44f7-486d-b3ba-df915eef1321" width="30" height="30"></video> 




## 備考


## Issue番号
Close #1893 

