### PR TITLE
タブ画面で現在開いているタブの設定状態をMenuから直接編集画面に遷移できるようにした

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/tab/TabFragment.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/tab/TabFragment.kt
@@ -177,7 +177,7 @@ class TabFragment : Fragment(R.layout.fragment_tab) {
                     else -> false
                 }
             }
-        })
+        }, viewLifecycleOwner, Lifecycle.State.RESUMED)
 
     }
 

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/tab/TabFragment.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/tab/TabFragment.kt
@@ -154,9 +154,21 @@ class TabFragment : Fragment(R.layout.fragment_tab) {
             Lifecycle.State.RESUMED
         ).launchIn(viewLifecycleOwner.lifecycleScope)
 
+        currentPageViewModel.currentType.onEach {
+            (requireActivity() as MenuHost).invalidateMenu()
+        }.flowWithLifecycle(
+            viewLifecycleOwner.lifecycle,
+            Lifecycle.State.RESUMED
+        ).launchIn(viewLifecycleOwner.lifecycleScope)
+
         (requireActivity() as MenuHost).addMenuProvider(object : MenuProvider {
             override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
                 menuInflater.inflate(R.menu.tab_pager_menu, menu)
+                val currentPageId = when(val type = currentPageViewModel.currentType.value) {
+                    CurrentPageType.Account -> null
+                    is CurrentPageType.Page -> type.pageId
+                }
+                menu.findItem(R.id.edit_tab).isVisible = currentPageId != null
                 applyMenuTint(requireActivity(), menu)
             }
 

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/tab/TabFragment.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/tab/TabFragment.kt
@@ -1,10 +1,17 @@
 package jp.panta.misskeyandroidclient.ui.tab
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.MenuHost
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -21,10 +28,14 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import net.pantasystem.milktea.app_store.account.AccountStore
 import net.pantasystem.milktea.common.Logger
+import net.pantasystem.milktea.common.ui.ApplyMenuTint
 import net.pantasystem.milktea.common.ui.AvatarIconView.Companion.setShape
 import net.pantasystem.milktea.common.ui.ToolbarSetter
 import net.pantasystem.milktea.common_android_ui.PageableFragmentFactory
+import net.pantasystem.milktea.common_viewmodel.CurrentPageType
+import net.pantasystem.milktea.common_viewmodel.CurrentPageableTimelineViewModel
 import net.pantasystem.milktea.model.account.page.Page
+import net.pantasystem.milktea.setting.activities.PageSettingActivity
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -47,6 +58,11 @@ class TabFragment : Fragment(R.layout.fragment_tab) {
 
     @Inject
     lateinit var loggerFactory: Logger.Factory
+
+    @Inject
+    lateinit var applyMenuTint: ApplyMenuTint
+
+    private val currentPageViewModel by activityViewModels<CurrentPageableTimelineViewModel>()
 
     private val mTabViewModel by viewModels<TabViewModel>()
 
@@ -137,6 +153,31 @@ class TabFragment : Fragment(R.layout.fragment_tab) {
             viewLifecycleOwner.lifecycle,
             Lifecycle.State.RESUMED
         ).launchIn(viewLifecycleOwner.lifecycleScope)
+
+        (requireActivity() as MenuHost).addMenuProvider(object : MenuProvider {
+            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                menuInflater.inflate(R.menu.tab_pager_menu, menu)
+                applyMenuTint(requireActivity(), menu)
+            }
+
+            override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                return when (menuItem.itemId) {
+                    R.id.edit_tab -> {
+                        when(val type = currentPageViewModel.currentType.value) {
+                            CurrentPageType.Account -> return false
+                            is CurrentPageType.Page -> {
+                                val intent =  Intent(requireContext(), PageSettingActivity::class.java).apply {
+                                    putExtra(PageSettingActivity.EXTRA_EDIT_TAB_ID, type.pageId)
+                                }
+                                startActivity(intent)
+                            }
+                        }
+                        true
+                    }
+                    else -> false
+                }
+            }
+        })
 
     }
 

--- a/modules/common_resource/src/main/res/menu/tab_pager_menu.xml
+++ b/modules/common_resource/src/main/res/menu/tab_pager_menu.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/edit_tab"
+        android:icon="@drawable/ic_edit_black_24dp"
+        android:title="@string/edit_tab"
+        app:showAsAction="never" />
+</menu>

--- a/modules/common_viewmodel/src/main/java/net/pantasystem/milktea/common_viewmodel/CurrentPageableTimelineViewModel.kt
+++ b/modules/common_viewmodel/src/main/java/net/pantasystem/milktea/common_viewmodel/CurrentPageableTimelineViewModel.kt
@@ -35,7 +35,7 @@ class CurrentPageableTimelineViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val _currentType = MutableStateFlow<CurrentPageType>(
-        CurrentPageType.Page(null, Pageable.HomeTimeline()))
+        CurrentPageType.Page(null, Pageable.HomeTimeline(), null))
 
     val currentType: StateFlow<CurrentPageType> = _currentType
 
@@ -43,8 +43,8 @@ class CurrentPageableTimelineViewModel @Inject constructor(
     private val _currentAccountId = MutableStateFlow<Long?>(null)
     val currentAccountId = _currentAccountId.asStateFlow()
 
-    fun setCurrentPageable(accountId: Long?, pageable: Pageable) {
-        _currentType.value = CurrentPageType.Page(accountId, pageable)
+    fun setCurrentPageable(accountId: Long?, pageable: Pageable, pageId: Long? = null,) {
+        _currentType.value = CurrentPageType.Page(accountId, pageable, pageId)
     }
 
     fun setCurrentPageType(type: CurrentPageType) {
@@ -54,6 +54,6 @@ class CurrentPageableTimelineViewModel @Inject constructor(
 }
 
 sealed interface CurrentPageType {
-    data class Page(val accountId: Long?, val pageable: Pageable) : CurrentPageType
+    data class Page(val accountId: Long?, val pageable: Pageable, val pageId: Long?) : CurrentPageType
     object Account : CurrentPageType
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
@@ -47,21 +47,26 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
         private const val EXTRA_PAGE = "jp.panta.misskeyandroidclient.EXTRA_PAGE"
         private const val EXTRA_PAGEABLE = "jp.panta.misskeyandroidclient.EXTRA_PAGEABLE"
         private const val EXTRA_ACCOUNT_ID = "jp.panta.misskeyandroidclient.EXTRA_ACCOUNT_ID"
+        private const val EXTRA_PAGE_ID = "jp.panta.misskeyandroidclient.EXTRA_PAGE_ID"
 
         fun newInstance(page: Page): TimelineFragment {
             return TimelineFragment().apply {
                 arguments = Bundle().apply {
                     putSerializable(EXTRA_PAGE, page)
+                    putLong(EXTRA_PAGE_ID, page.pageId)
                 }
             }
         }
 
-        fun newInstance(pageable: Pageable, accountId: Long? = null): TimelineFragment {
+        fun newInstance(pageable: Pageable, accountId: Long? = null, pageId: Long? = null): TimelineFragment {
             return TimelineFragment().apply {
                 arguments = Bundle().apply {
                     putSerializable(EXTRA_PAGEABLE, pageable)
                     if (accountId != null) {
                         putLong(EXTRA_ACCOUNT_ID, accountId)
+                    }
+                    if (pageId != null) {
+                        putLong(EXTRA_PAGE_ID, pageId)
                     }
                 }
             }
@@ -125,6 +130,12 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
 
     private val accountId: Long? by lazy {
         arguments?.getLong(EXTRA_ACCOUNT_ID, -1).takeIf {
+            it != -1L
+        }
+    }
+
+    private val pageId by lazy {
+        arguments?.getLong(EXTRA_PAGE_ID, -1).takeIf {
             it != -1L
         }
     }
@@ -302,7 +313,7 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
         isShowing = true
         mViewModel.onResume()
 
-        currentPageableTimelineViewModel.setCurrentPageable(mViewModel.accountId?.value, mPageable)
+        currentPageableTimelineViewModel.setCurrentPageable(mViewModel.accountId?.value, mPageable, pageId)
         try {
             layoutManager.scrollToPositionWithOffset(mViewModel.position, mViewModel.offset)
         } catch (_: Exception) {

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/PageSettingActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/PageSettingActivity.kt
@@ -13,8 +13,6 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.composethemeadapter.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import net.pantasystem.milktea.common.ui.ApplyTheme
@@ -41,10 +39,12 @@ import net.pantasystem.milktea.setting.viewmodel.page.PageSettingViewModel
 import javax.inject.Inject
 
 @Suppress("DEPRECATION")
-@FlowPreview
-@ExperimentalCoroutinesApi
 @AndroidEntryPoint
 class PageSettingActivity : AppCompatActivity() {
+
+    companion object {
+        const val EXTRA_EDIT_TAB_ID = "edit_tab_id"
+    }
 
 
     @Inject
@@ -171,6 +171,15 @@ class PageSettingActivity : AppCompatActivity() {
                     dragDropState = dragAndDropState,
                 )
             }
+        }
+
+        if (savedInstanceState == null) {
+            mPageSettingViewModel.onEditTab(
+                intent.getLongExtra(
+                    EXTRA_EDIT_TAB_ID,
+                    -1,
+                )
+            )
         }
 
     }

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/page/PageSettingViewModel.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/page/PageSettingViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import net.pantasystem.milktea.app_store.account.AccountStore
 import net.pantasystem.milktea.app_store.setting.SettingStore
+import net.pantasystem.milktea.common.mapCancellableCatching
 import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common_android.resource.StringSource
 import net.pantasystem.milktea.model.account.Account
@@ -304,6 +305,23 @@ class PageSettingViewModel @Inject constructor(
 
     fun onEditButtonClicked(page: Page) {
         _pageOnUpdateEvent.tryEmit(page)
+    }
+
+    fun onEditTab(pageId: Long) {
+        viewModelScope.launch {
+            accountRepository.findAll().mapCancellableCatching { accounts ->
+                accounts.map {
+                    it.pages
+                }.flatten().firstOrNull {
+                    it.pageId == pageId
+                }
+            }.onSuccess { page ->
+                if (page != null) {
+                    _pageOnUpdateEvent.tryEmit(page)
+                }
+            }
+
+        }
     }
 
 }


### PR DESCRIPTION
## やったこと
現状特定のタブの設定状態(タブの名称や、スクロールポジションの保持など）は、
タブ編集画面の一覧から対象のタブを選択して編集する必要があった。
これをタブ画面から現在開いているタブの編集画面を直接開けるようにした。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号

Closed #1900 

