### PR TITLE
画像詳細画面で画像読み込み時にはローディングを表示するようにした

### DIFF
--- a/modules/features/media/build.gradle
+++ b/modules/features/media/build.gradle
@@ -86,4 +86,7 @@ dependencies {
 
     testImplementation libs.junit.jupiter.api
     testRuntimeOnly libs.junit.jupiter.engine
+
+    implementation libs.lifecycle.viewmodel
+    implementation libs.fragment.ktx
 }

--- a/modules/features/media/src/main/java/net/pantasystem/milktea/media/ImageFragment.kt
+++ b/modules/features/media/src/main/java/net/pantasystem/milktea/media/ImageFragment.kt
@@ -1,24 +1,32 @@
 package net.pantasystem.milktea.media
 
+import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.fragment.app.Fragment
-import com.bumptech.glide.Glide
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.request.RequestListener
+import com.bumptech.glide.request.target.Target
 import com.wada811.databinding.dataBinding
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import net.pantasystem.milktea.common.glide.GlideApp
 import net.pantasystem.milktea.media.databinding.FragmentImageBinding
 
 class ImageFragment : Fragment(R.layout.fragment_image){
 
     companion object{
-        private const val TAG = "ImageFragment"
-        private const val EXTRA_IMAGE_URL = "jp.panta.misskeyandroidclient.ui.media.EXTRA_IMAGE_URL"
-        private const val EXTRA_IMAGE_URI = "jp.panta.misskeyandroidclient.ui.media.EXTRA_IMAGE_URI"
         private const val EXTRA_INDEX = "jp.panta.misskeyandroidclient.ui.media.EXTRA_INDEX"
         fun newInstance(index: Int, url: String): ImageFragment {
             val bundle = Bundle().apply{
-                putString(EXTRA_IMAGE_URL, url)
+                putString(ImageViewModel.EXTRA_IMAGE_URL, url)
                 putInt(EXTRA_INDEX, index)
             }
             return ImageFragment().apply{
@@ -29,7 +37,7 @@ class ImageFragment : Fragment(R.layout.fragment_image){
         fun newInstance(index: Int, uri: Uri): ImageFragment {
             return ImageFragment().apply{
                 arguments = Bundle().apply{
-                    putString(EXTRA_IMAGE_URI, uri.toString())
+                    putString(ImageViewModel.EXTRA_IMAGE_URI, uri.toString())
                     putInt(EXTRA_INDEX, index)
                 }
             }
@@ -43,30 +51,47 @@ class ImageFragment : Fragment(R.layout.fragment_image){
     var index = 0
     val binding: FragmentImageBinding by dataBinding()
 
+    private val viewModel by viewModels<ImageViewModel>()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val url = arguments?.getString(EXTRA_IMAGE_URL)
-        val extraUri = arguments?.getString(EXTRA_IMAGE_URI)
-        val uri = if(extraUri == null) null else Uri.parse(extraUri)
         index = arguments?.getInt(EXTRA_INDEX)?: 0
-
-        if(url == null && uri == null){
-            Log.e(TAG, "EXTRA_IMAGE_URL must not null")
-            return
-        }
 
         binding.swipeFinishLayout.setOnFinishEventListener {
             requireActivity().finish()
         }
 
-        Glide.with(view.context).let {
-            if (uri == null) {
-                it.load(url)
-            } else {
-                it.load(uri)
-            }
-        }.into(binding.imageView)
+
+        viewModel.uiState.map {
+            it.uri ?: it.url
+        }.distinctUntilChanged().onEach { url ->
+            GlideApp.with(view)
+                .load(url)
+                .addListener(object : RequestListener<Drawable?> {
+                    override fun onLoadFailed(
+                        e: GlideException?,
+                        model: Any?,
+                        target: Target<Drawable?>?,
+                        isFirstResource: Boolean
+                    ): Boolean {
+                        viewModel.onLoadFailed()
+                        return false
+                    }
+
+                    override fun onResourceReady(
+                        resource: Drawable?,
+                        model: Any?,
+                        target: Target<Drawable?>?,
+                        dataSource: DataSource?,
+                        isFirstResource: Boolean
+                    ): Boolean {
+                        viewModel.onResourceReady()
+                        return false
+                    }
+                })
+                .into(binding.imageView)
+        }.flowWithLifecycle(lifecycle).launchIn(lifecycleScope)
     }
 
     override fun onResume() {

--- a/modules/features/media/src/main/java/net/pantasystem/milktea/media/ImageFragment.kt
+++ b/modules/features/media/src/main/java/net/pantasystem/milktea/media/ImageFragment.kt
@@ -4,6 +4,7 @@ import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
@@ -91,6 +92,12 @@ class ImageFragment : Fragment(R.layout.fragment_image){
                     }
                 })
                 .into(binding.imageView)
+        }.flowWithLifecycle(lifecycle).launchIn(lifecycleScope)
+
+        viewModel.uiState.map {
+            it.isLoading
+        }.distinctUntilChanged().onEach {
+            binding.progressBar.isVisible = it
         }.flowWithLifecycle(lifecycle).launchIn(lifecycleScope)
     }
 

--- a/modules/features/media/src/main/java/net/pantasystem/milktea/media/ImageViewModel.kt
+++ b/modules/features/media/src/main/java/net/pantasystem/milktea/media/ImageViewModel.kt
@@ -1,0 +1,53 @@
+package net.pantasystem.milktea.media
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import javax.inject.Inject
+
+@HiltViewModel
+class ImageViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    companion object {
+        const val EXTRA_IMAGE_URL = "jp.panta.misskeyandroidclient.ui.media.EXTRA_IMAGE_URL"
+        const val EXTRA_IMAGE_URI = "jp.panta.misskeyandroidclient.ui.media.EXTRA_IMAGE_URI"
+    }
+
+    private val url = savedStateHandle.getStateFlow<String?>(
+        EXTRA_IMAGE_URL,
+        null,
+    )
+
+    private val uri = savedStateHandle.getStateFlow<String?>(
+        EXTRA_IMAGE_URI,
+        null,
+    )
+
+    private val isImageLoading = MutableStateFlow(true)
+
+    val uiState = combine(url, uri, isImageLoading) { url, uri, loading ->
+        ImageUiState(
+            url = url,
+            uri = uri,
+            isLoading = loading,
+        )
+    }
+
+    fun onResourceReady() {
+        isImageLoading.value = false
+    }
+
+    fun onLoadFailed() {
+        isImageLoading.value = false
+    }
+}
+
+data class ImageUiState(
+    val uri: String?,
+    val url: String?,
+    val isLoading: Boolean = false,
+)

--- a/modules/features/media/src/main/java/net/pantasystem/milktea/media/MediaActivity.kt
+++ b/modules/features/media/src/main/java/net/pantasystem/milktea/media/MediaActivity.kt
@@ -11,9 +11,7 @@ import android.view.MenuItem
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
-import androidx.fragment.app.FragmentPagerAdapter
 import androidx.work.WorkManager
 import dagger.hilt.android.AndroidEntryPoint
 import net.pantasystem.milktea.common.ui.ApplyTheme
@@ -55,12 +53,12 @@ class MediaNavigationImpl @Inject constructor(
     }
 }
 
+sealed class Media : Serializable {
+    data class FileMedia(val file: File) : Media()
+}
 @AndroidEntryPoint
 class MediaActivity : AppCompatActivity() {
 
-    private sealed class Media : Serializable {
-        data class FileMedia(val file: File) : Media()
-    }
 
 
     companion object {
@@ -100,7 +98,7 @@ class MediaActivity : AppCompatActivity() {
 
         val fileCurrentIndex = intent.getIntExtra(MediaNavigationKeys.EXTRA_FILE_CURRENT_INDEX, 0)
         val list = when {
-            files != null && files.isNotEmpty() -> {
+            !files.isNullOrEmpty() -> {
                 files.map {
                     Media.FileMedia(it)
                 }
@@ -116,7 +114,7 @@ class MediaActivity : AppCompatActivity() {
 
         mMedias = list
 
-        val pagerAdapter = MediaPagerAdapter(list)
+        val pagerAdapter = MediaPagerAdapter(supportFragmentManager, list)
         mBinding.mediaViewPager.adapter = pagerAdapter
 
         mBinding.mediaViewPager.currentItem = fileCurrentIndex
@@ -177,27 +175,6 @@ class MediaActivity : AppCompatActivity() {
             )
     }
 
-    private inner class MediaPagerAdapter(
-        private val list: List<Media>
-    ) : FragmentPagerAdapter(supportFragmentManager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
-        override fun getCount(): Int {
-            return list.size
-        }
 
-        override fun getItem(position: Int): Fragment {
-            return when (val item = list[position]) {
-                is Media.FileMedia -> createFragment(position, item.file)
-            }
-        }
-    }
-
-    private fun createFragment(index: Int, file: File): Fragment {
-
-        return if (file.type?.contains("image") == true) {
-            ImageFragment.newInstance(index, file)
-        } else {
-            PlayerFragment.newInstance(index, file.path!!)
-        }
-    }
 
 }

--- a/modules/features/media/src/main/java/net/pantasystem/milktea/media/MediaActivity.kt
+++ b/modules/features/media/src/main/java/net/pantasystem/milktea/media/MediaActivity.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package net.pantasystem.milktea.media
 
 import android.app.Activity
@@ -95,31 +93,6 @@ class MediaActivity : AppCompatActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.title = ""
 
-        val file = intent.getSerializableExtra(MediaNavigationKeys.EXTRA_FILE) as File?
-
-        val files =
-            (intent.getSerializableExtra(MediaNavigationKeys.EXTRA_FILES) as List<*>?)?.mapNotNull {
-                it as File?
-            }
-
-
-        val list = when {
-            !files.isNullOrEmpty() -> {
-                files.map {
-                    Media.FileMedia(it)
-                }
-            }
-            file != null -> {
-                listOf<Media>(Media.FileMedia(file))
-            }
-            else -> {
-                Log.e(MediaNavigationKeys.TAG, "params must not null")
-                throw IllegalArgumentException()
-            }
-        }
-
-        mMedias = list
-
         val pagerAdapter = MediaPagerAdapter(supportFragmentManager)
         mBinding.mediaViewPager.adapter = pagerAdapter
 
@@ -127,7 +100,7 @@ class MediaActivity : AppCompatActivity() {
         viewModel.uiState.onEach { uiState ->
             pagerAdapter.setFiles(uiState.medias)
             mBinding.mediaViewPager.currentItem = uiState.currentIndex
-
+            mMedias = uiState.medias
         }.flowWithLifecycle(lifecycle).launchIn(lifecycleScope)
     }
 

--- a/modules/features/media/src/main/java/net/pantasystem/milktea/media/MediaPagerAdapter.kt
+++ b/modules/features/media/src/main/java/net/pantasystem/milktea/media/MediaPagerAdapter.kt
@@ -1,0 +1,33 @@
+@file:Suppress("DEPRECATION")
+
+package net.pantasystem.milktea.media
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentPagerAdapter
+
+@Suppress("DEPRECATION")
+class MediaPagerAdapter(
+    fragmentManager: FragmentManager,
+    private val list: List<Media>
+) : FragmentPagerAdapter(fragmentManager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
+    override fun getCount(): Int {
+        return list.size
+    }
+
+    override fun getItem(position: Int): Fragment {
+        return when (val item = list[position]) {
+            is Media.FileMedia -> createFragment(position, item.file)
+        }
+    }
+
+    private fun createFragment(index: Int, file: File): Fragment {
+
+        return if (file.type?.contains("image") == true) {
+            ImageFragment.newInstance(index, file)
+        } else {
+            PlayerFragment.newInstance(index, file.path!!)
+        }
+    }
+
+}

--- a/modules/features/media/src/main/java/net/pantasystem/milktea/media/MediaPagerAdapter.kt
+++ b/modules/features/media/src/main/java/net/pantasystem/milktea/media/MediaPagerAdapter.kt
@@ -9,16 +9,24 @@ import androidx.fragment.app.FragmentPagerAdapter
 @Suppress("DEPRECATION")
 class MediaPagerAdapter(
     fragmentManager: FragmentManager,
-    private val list: List<Media>
 ) : FragmentPagerAdapter(fragmentManager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
+
+    private var _files = emptyList<Media>()
+
     override fun getCount(): Int {
-        return list.size
+        return _files.size
     }
 
     override fun getItem(position: Int): Fragment {
-        return when (val item = list[position]) {
+        return when (val item = _files[position]) {
             is Media.FileMedia -> createFragment(position, item.file)
         }
+    }
+
+    fun setFiles(files: List<Media>) {
+        if (_files == files) return
+        _files = files
+        notifyDataSetChanged()
     }
 
     private fun createFragment(index: Int, file: File): Fragment {

--- a/modules/features/media/src/main/java/net/pantasystem/milktea/media/MediaViewModel.kt
+++ b/modules/features/media/src/main/java/net/pantasystem/milktea/media/MediaViewModel.kt
@@ -1,8 +1,10 @@
 package net.pantasystem.milktea.media
 
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.combine
 import net.pantasystem.milktea.common_navigation.MediaNavigationKeys
 import javax.inject.Inject
 
@@ -12,9 +14,48 @@ class MediaViewModel @Inject constructor(
 ): ViewModel() {
 
 
-    val files = savedStateHandle.getStateFlow(
+    private val files = savedStateHandle.getStateFlow<List<File>?>(
         MediaNavigationKeys.EXTRA_FILES,
-        emptyList<File>()
+        null
     )
 
+    private val file = savedStateHandle.getStateFlow<File?>(
+        MediaNavigationKeys.EXTRA_FILE,
+        null,
+    )
+
+    val medias = combine(files, file) { files , file ->
+        when {
+            !files.isNullOrEmpty() -> {
+                files.map {
+                    Media.FileMedia(it)
+                }
+            }
+            file != null -> {
+                listOf<Media>(Media.FileMedia(file))
+            }
+            else -> {
+                Log.e(MediaNavigationKeys.TAG, "params must not null")
+                throw IllegalArgumentException()
+            }
+        }
+    }
+
+    private val currentIndex = savedStateHandle.getStateFlow<Int>(
+        MediaNavigationKeys.EXTRA_FILE_CURRENT_INDEX,
+        0,
+    )
+
+    val uiState = combine(medias, currentIndex) { medias, currentIndex ->
+        MediaUiState(medias, currentIndex)
+    }
+
+    fun setCurrentIndex(index: Int) {
+        savedStateHandle[MediaNavigationKeys.EXTRA_FILE_CURRENT_INDEX] = index
+    }
 }
+
+data class MediaUiState(
+    val medias: List<Media>,
+    val currentIndex: Int,
+)

--- a/modules/features/media/src/main/java/net/pantasystem/milktea/media/MediaViewModel.kt
+++ b/modules/features/media/src/main/java/net/pantasystem/milktea/media/MediaViewModel.kt
@@ -1,0 +1,20 @@
+package net.pantasystem.milktea.media
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import net.pantasystem.milktea.common_navigation.MediaNavigationKeys
+import javax.inject.Inject
+
+@HiltViewModel
+class MediaViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+): ViewModel() {
+
+
+    val files = savedStateHandle.getStateFlow(
+        MediaNavigationKeys.EXTRA_FILES,
+        emptyList<File>()
+    )
+
+}

--- a/modules/features/media/src/main/res/layout/fragment_image.xml
+++ b/modules/features/media/src/main/res/layout/fragment_image.xml
@@ -1,14 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <net.pantasystem.milktea.media.SwipeFinishLayout
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:id="@+id/swipeFinishLayout">
-        <com.github.chrisbanes.photoview.PhotoView
-            android:id="@+id/imageView"
+        >
+        <net.pantasystem.milktea.media.SwipeFinishLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"/>
-    </net.pantasystem.milktea.media.SwipeFinishLayout>
+            android:layout_height="match_parent"
+            android:id="@+id/swipeFinishLayout">
+            <com.github.chrisbanes.photoview.PhotoView
+                android:id="@+id/imageView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"/>
+
+            <ProgressBar
+                android:id="@+id/progressBar"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center" />
+        </net.pantasystem.milktea.media.SwipeFinishLayout>
+    </FrameLayout>
 
 </layout>


### PR DESCRIPTION
## やったこと
画像詳細画面で画像読み込み時にはローディングを表示するようにした。
そのために、状態を管理しやすくするためにViewModelに状態を保持するようにした。
また、レイアウトファイルにProgressの表示状態を追加しました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1913 


