### PR TITLE
クライアント側でNyaize処理を実行するようにした

### DIFF
--- a/app/src/test/java/net/pantasystem/milktea/data/infrastructure/note/impl/db/NoteRecordTest.kt
+++ b/app/src/test/java/net/pantasystem/milktea/data/infrastructure/note/impl/db/NoteRecordTest.kt
@@ -296,6 +296,7 @@ internal class NoteRecordTest {
                 ),
                 isAcceptingOnlyLikeReaction = false,
                 isNotAcceptingSensitiveReaction = true,
+                isRequireNyaize = true,
             )
         )
         record.applyModel(note)
@@ -314,6 +315,10 @@ internal class NoteRecordTest {
         Assertions.assertEquals(
             true,
             record.misskeyIsNotAcceptingSensitiveReaction
+        )
+        Assertions.assertEquals(
+            true,
+            record.misskeyIsRequireNyaize,
         )
     }
 

--- a/modules/common/src/main/java/net/pantasystem/milktea/common/paginator/FuturePagingController.kt
+++ b/modules/common/src/main/java/net/pantasystem/milktea/common/paginator/FuturePagingController.kt
@@ -30,7 +30,7 @@ class FuturePagingController<DTO, E>(
 
     override suspend fun loadFuture(): Result<Int> {
         if (locker.mutex.isLocked) {
-            return Result.failure(IllegalStateException())
+            return Result.failure(IllegalStateException("ローディング中にさらにローディング処理を実行することはできません"))
         }
         return locker.mutex.withLock {
 

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/nyaize/Nyaize.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/nyaize/Nyaize.kt
@@ -1,0 +1,31 @@
+package net.pantasystem.milktea.common_android.nyaize
+
+fun nyaize(text: String): String {
+    // 日本語の変換
+    var result = text.replace("な", "にゃ").replace("ナ", "ニャ").replace("ﾅ", "ﾆｬ")
+
+    // 英語の変換
+    result = result.replace(Regex("(?<=n)a", RegexOption.IGNORE_CASE)) {
+        if (it.value == "A") "YA" else "ya"
+    }
+    result = result.replace(Regex("(?<=morn)ing", RegexOption.IGNORE_CASE)) {
+        if (it.value == "ING") "YAN" else "yan"
+    }
+    result = result.replace(Regex("(?<=every)one", RegexOption.IGNORE_CASE)) {
+        if (it.value == "ONE") "NYAN" else "nyan"
+    }
+
+    // 韓国語の変換
+    result = result.replace(Regex("[나-낳]")) {
+        val offset = '냐'.code - '나'.code
+        it.value[0].plus(offset).toChar().toString()
+    }
+    result = result.replace(Regex("(다$)|(다(?=[.]))|(다(?= ))|(다(?=!))|(다(?=\\?))", RegexOption.MULTILINE)) {
+        "다냥"
+    }
+    result = result.replace(Regex("(야(?=\\?))|(야$)|(야(?= ))", RegexOption.MULTILINE)) {
+        "냥"
+    }
+
+    return result
+}

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/TextType.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/TextType.kt
@@ -18,7 +18,7 @@ sealed interface TextType {
     ) : TextType
 }
 
-fun getTextType(account: Account, note: NoteRelation, instanceEmojis: Map<String, CustomEmoji>?): TextType? {
+fun getTextType(account: Account, note: NoteRelation, instanceEmojis: Map<String, CustomEmoji>?, isRequirePerformNyaize: Boolean = false): TextType? {
     return when (account.instanceType) {
         Account.InstanceType.MISSKEY, Account.InstanceType.FIREFISH -> {
             val root = MFMParser.parse(
@@ -27,7 +27,8 @@ fun getTextType(account: Account, note: NoteRelation, instanceEmojis: Map<String
                 instanceEmojis,
                 userHost = note.user
                     .host,
-                accountHost = account.getHost()
+                accountHost = account.getHost(),
+                isRequireProcessNyaize = isRequirePerformNyaize,
             )
             note.note.text?.let {
                 TextType.Misskey(

--- a/modules/data/objectbox-models/default.json
+++ b/modules/data/objectbox-models/default.json
@@ -5,7 +5,7 @@
   "entities": [
     {
       "id": "1:4355718382021751829",
-      "lastPropertyId": "54:1696546822899785376",
+      "lastPropertyId": "55:68607803971520561",
       "name": "NoteRecord",
       "properties": [
         {
@@ -286,6 +286,11 @@
           "id": "54:1696546822899785376",
           "name": "customEmojiUrlAndCachePathMap",
           "type": 13
+        },
+        {
+          "id": "55:68607803971520561",
+          "name": "misskeyIsRequireNyaize",
+          "type": 1
         }
       ],
       "relations": []

--- a/modules/data/objectbox-models/default.json.bak
+++ b/modules/data/objectbox-models/default.json.bak
@@ -443,64 +443,6 @@
         }
       ],
       "relations": []
-    },
-    {
-      "id": "6:5418605338436881136",
-      "lastPropertyId": "9:4598656151033408118",
-      "name": "CustomEmojiRecord",
-      "properties": [
-        {
-          "id": "1:271785103207869909",
-          "name": "id",
-          "type": 6,
-          "flags": 1
-        },
-        {
-          "id": "2:6655539627519293459",
-          "name": "serverId",
-          "type": 9
-        },
-        {
-          "id": "3:211101382978291231",
-          "name": "name",
-          "indexId": "11:3813410665521821846",
-          "type": 9,
-          "flags": 2048
-        },
-        {
-          "id": "4:7927231724161011575",
-          "name": "emojiHost",
-          "indexId": "12:6383965324106330542",
-          "type": 9,
-          "flags": 2048
-        },
-        {
-          "id": "5:2060901050158269776",
-          "name": "url",
-          "type": 9
-        },
-        {
-          "id": "6:1468865394375722898",
-          "name": "uri",
-          "type": 9
-        },
-        {
-          "id": "7:3770123434781396120",
-          "name": "type",
-          "type": 9
-        },
-        {
-          "id": "8:8187355251103755613",
-          "name": "category",
-          "type": 9
-        },
-        {
-          "id": "9:4598656151033408118",
-          "name": "aliases",
-          "type": 30
-        }
-      ],
-      "relations": []
     }
   ],
   "lastEntityId": "6:5418605338436881136",
@@ -509,9 +451,24 @@
   "lastSequenceId": "0:0",
   "modelVersion": 5,
   "modelVersionParserMinimum": 5,
-  "retiredEntityUids": [],
-  "retiredIndexUids": [],
-  "retiredPropertyUids": [],
+  "retiredEntityUids": [
+    5418605338436881136
+  ],
+  "retiredIndexUids": [
+    3813410665521821846,
+    6383965324106330542
+  ],
+  "retiredPropertyUids": [
+    271785103207869909,
+    6655539627519293459,
+    211101382978291231,
+    7927231724161011575,
+    2060901050158269776,
+    1468865394375722898,
+    3770123434781396120,
+    8187355251103755613,
+    4598656151033408118
+  ],
   "retiredRelationUids": [],
   "version": 1
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/converters/NoteDTOEntityConverter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/converters/NoteDTOEntityConverter.kt
@@ -10,8 +10,6 @@ import net.pantasystem.milktea.model.drive.FileProperty
 import net.pantasystem.milktea.model.emoji.CustomEmojiAspectRatioDataSource
 import net.pantasystem.milktea.model.image.ImageCacheRepository
 import net.pantasystem.milktea.model.instance.InstanceInfoService
-import net.pantasystem.milktea.model.instance.InstanceInfoType
-import net.pantasystem.milktea.model.instance.Version
 import net.pantasystem.milktea.model.note.Note
 import net.pantasystem.milktea.model.note.Visibility
 import net.pantasystem.milktea.model.note.poll.Poll
@@ -30,8 +28,8 @@ class NoteDTOEntityConverter @Inject constructor(
     suspend fun convert(noteDTO: NoteDTO, account: Account): Note {
         val emojis = (noteDTO.emojiList + (noteDTO.reactionEmojiList))
 
-        val instanceInfo = instanceInfoService.find(account.getHost()).getOrNull()
-        val isRequireNyaize = instanceInfo is InstanceInfoType.Misskey && instanceInfo.meta.getVersion() >= Version("2023.10.2")
+        val instanceInfo = instanceInfoService.find(account.normalizedInstanceUri).getOrNull()
+        val isRequireNyaize = (instanceInfo?.isRequirePerformNyaizeFrontend ?: false)
                 && (noteDTO.user.isCat ?: false)
         val aspects = customEmojiAspectRatioDataSource.findIn(emojis.mapNotNull {
             it.url ?: it.uri

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/note/impl/db/NoteRecord.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/note/impl/db/NoteRecord.kt
@@ -93,6 +93,7 @@ data class NoteRecord(
 
     var customEmojiAspectRatioMap: MutableMap<String, String>? = null,
     var customEmojiUrlAndCachePathMap: MutableMap<String, String?>? = null,
+    var misskeyIsRequireNyaize: Boolean = false,
 ) {
 
     companion object {
@@ -172,6 +173,7 @@ data class NoteRecord(
                 misskeyChannelName = t.channel?.name
                 misskeyIsAcceptingOnlyLikeReaction = t.isAcceptingOnlyLikeReaction
                 misskeyIsNotAcceptingSensitiveReaction = t.isNotAcceptingSensitiveReaction
+                misskeyIsRequireNyaize = t.isRequireNyaize
             }
         }
         customEmojiAspectRatioMap = model.emojis?.mapNotNull {  emoji ->
@@ -241,6 +243,7 @@ data class NoteRecord(
                         },
                         isAcceptingOnlyLikeReaction = misskeyIsAcceptingOnlyLikeReaction,
                         isNotAcceptingSensitiveReaction = misskeyIsNotAcceptingSensitiveReaction,
+                        isRequireNyaize = misskeyIsRequireNyaize,
                     )
                 }
                 "mastodon" -> {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/MediatorUserDataSource.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/MediatorUserDataSource.kt
@@ -254,8 +254,8 @@ class MediatorUserDataSource @Inject constructor(
         if (serverIds.isEmpty()) {
             return flowOf(emptyList())
         }
-        return serverIds.distinct().chunked(50).map {
-            userDao.observeInServerIds(accountId, serverIds).distinctUntilChanged().map { list ->
+        return serverIds.distinct().chunked(500).map { chunkedIds ->
+            userDao.observeInServerIds(accountId, chunkedIds).distinctUntilChanged().map { list ->
                 list.map {
                     it.toModel()
                 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/MediatorUserDataSource.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/MediatorUserDataSource.kt
@@ -81,11 +81,11 @@ class MediatorUserDataSource @Inject constructor(
         isSimple: Boolean
     ): Result<List<User>> = runCancellableCatching {
         withContext(ioDispatcher) {
-            val list = serverIds.distinct().chunked(100).map {
+            val list = serverIds.distinct().chunked(100).map { chunkedIds ->
                 if (isSimple) {
-                    userDao.getSimplesInServerIds(accountId, serverIds)
+                    userDao.getSimplesInServerIds(accountId, chunkedIds)
                 } else {
-                    userDao.getInServerIds(accountId, serverIds)
+                    userDao.getInServerIds(accountId, chunkedIds)
                 }.map {
                     it.toModel()
                 }

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/converters/NoteDTOEntityConverterTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/converters/NoteDTOEntityConverterTest.kt
@@ -1,6 +1,5 @@
 package net.pantasystem.milktea.data.converters
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import net.pantasystem.milktea.api.misskey.notes.NoteDTO
@@ -19,7 +18,6 @@ import org.mockito.kotlin.mock
 
 class NoteDTOEntityConverterTest {
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun convert() = runTest {
 

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/converters/NoteDTOEntityConverterTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/converters/NoteDTOEntityConverterTest.kt
@@ -7,6 +7,8 @@ import net.pantasystem.milktea.api.misskey.notes.NoteDTO
 import net.pantasystem.milktea.api.misskey.notes.NoteVisibilityType
 import net.pantasystem.milktea.api.misskey.users.UserDTO
 import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.instance.InstanceInfoType
+import net.pantasystem.milktea.model.instance.Meta
 import net.pantasystem.milktea.model.note.Note
 import net.pantasystem.milktea.model.user.User
 import org.junit.jupiter.api.Assertions
@@ -31,6 +33,17 @@ class NoteDTOEntityConverterTest {
                 onBlocking {
                     findBySourceUrls(any())
                 } doReturn emptyList()
+            },
+            mock() {
+                onBlocking {
+                    find(any())
+                } doReturn Result.success(
+                    InstanceInfoType.Misskey(
+                        Meta(
+                            uri = "https://misskey.pantasystem.com",
+                        )
+                    )
+                )
             }
         )
 

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/converters/NoteDTOEntityConverterTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/converters/NoteDTOEntityConverterTest.kt
@@ -106,4 +106,187 @@ class NoteDTOEntityConverterTest {
         Assertions.assertEquals(noteDTO.text, result.text)
 
     }
+
+    @Test
+    fun convert_WhenRequireNyaize() = runTest {
+
+        val converter = NoteDTOEntityConverter(
+            mock() {
+                onBlocking {
+                    findIn(any())
+                } doReturn Result.success(emptyList())
+            },
+            mock() {
+                onBlocking {
+                    findBySourceUrls(any())
+                } doReturn emptyList()
+            },
+            mock() {
+                onBlocking {
+                    find(any())
+                } doReturn Result.success(
+                    InstanceInfoType.Misskey(
+                        Meta(
+                            uri = "https://misskey.pantasystem.com",
+                            version = "2023.10.2"
+                        )
+                    )
+                )
+            }
+        )
+
+        val account = Account(
+            remoteId = "test-id",
+            instanceDomain = "https://misskey.pantasystem.com",
+            userName = "Panta",
+            instanceType = Account.InstanceType.MISSKEY,
+            token = "",
+        ).copy(accountId = 1L)
+
+        val noteDTO = NoteDTO(
+            id = "noteId",
+            createdAt = Clock.System.now(),
+            text = "test",
+            cw = "cw",
+            userId = "user-1",
+            replyId = "reply-id",
+            renoteId = "renote-id",
+            viaMobile = false,
+            visibility = NoteVisibilityType.Public,
+            localOnly = false,
+            visibleUserIds = listOf(),
+            rawReactionEmojis = net.pantasystem.milktea.api.misskey.emoji.EmojisType.None,
+            url = null,
+            uri = null,
+            renoteCount = 0,
+            reactionCounts = null,
+            rawEmojis = null,
+            replyCount = 0,
+            user = UserDTO(
+                id = "idididi",
+                userName = "test",
+                isCat = true,
+            ),
+            files = listOf(),
+            fileIds = listOf(),
+            poll = null,
+            reNote = null,
+            reply = null,
+            myReaction = "😇",
+            tmpFeaturedId = null,
+            promotionId = null,
+            channelId = null,
+            app = null,
+            channel = null
+        )
+
+        val result = converter.convert(
+            noteDTO, account
+        )
+        Assertions.assertEquals(Note.Id(account.accountId, noteDTO.id), result.id)
+        Assertions.assertEquals(noteDTO.cw, result.cw)
+        Assertions.assertEquals(noteDTO.text, result.text)
+        Assertions.assertEquals(User.Id(account.accountId, noteDTO.userId), result.userId)
+        Assertions.assertEquals(noteDTO.replyId?.let {
+            Note.Id(account.accountId, it)
+        }, result.replyId)
+        Assertions.assertEquals(noteDTO.renoteId?.let {
+            Note.Id(account.accountId, it)
+        }, result.renoteId)
+        Assertions.assertEquals(noteDTO.cw, result.cw)
+        Assertions.assertEquals(noteDTO.text, result.text)
+        Assertions.assertEquals(true, (result.type as Note.Type.Misskey).isRequireNyaize)
+    }
+
+
+    @Test
+    fun convert_WhenRequireNyaizeAndGiveNotCat() = runTest {
+
+        val converter = NoteDTOEntityConverter(
+            mock() {
+                onBlocking {
+                    findIn(any())
+                } doReturn Result.success(emptyList())
+            },
+            mock() {
+                onBlocking {
+                    findBySourceUrls(any())
+                } doReturn emptyList()
+            },
+            mock() {
+                onBlocking {
+                    find(any())
+                } doReturn Result.success(
+                    InstanceInfoType.Misskey(
+                        Meta(
+                            uri = "https://misskey.pantasystem.com",
+                            version = "2023.10.2"
+                        )
+                    )
+                )
+            }
+        )
+
+        val account = Account(
+            remoteId = "test-id",
+            instanceDomain = "https://misskey.pantasystem.com",
+            userName = "Panta",
+            instanceType = Account.InstanceType.MISSKEY,
+            token = "",
+        ).copy(accountId = 1L)
+
+        val noteDTO = NoteDTO(
+            id = "noteId",
+            createdAt = Clock.System.now(),
+            text = "test",
+            cw = "cw",
+            userId = "user-1",
+            replyId = "reply-id",
+            renoteId = "renote-id",
+            viaMobile = false,
+            visibility = NoteVisibilityType.Public,
+            localOnly = false,
+            visibleUserIds = listOf(),
+            rawReactionEmojis = net.pantasystem.milktea.api.misskey.emoji.EmojisType.None,
+            url = null,
+            uri = null,
+            renoteCount = 0,
+            reactionCounts = null,
+            rawEmojis = null,
+            replyCount = 0,
+            user = UserDTO(
+                id = "idididi",
+                userName = "test",
+                isCat = false,
+            ),
+            files = listOf(),
+            fileIds = listOf(),
+            poll = null,
+            reNote = null,
+            reply = null,
+            myReaction = "😇",
+            tmpFeaturedId = null,
+            promotionId = null,
+            channelId = null,
+            app = null,
+            channel = null
+        )
+
+        val result = converter.convert(
+            noteDTO, account
+        )
+        Assertions.assertEquals(Note.Id(account.accountId, noteDTO.id), result.id)
+        Assertions.assertEquals(noteDTO.cw, result.cw)
+        Assertions.assertEquals(noteDTO.text, result.text)
+        Assertions.assertEquals(User.Id(account.accountId, noteDTO.userId), result.userId)
+        Assertions.assertEquals(noteDTO.replyId?.let {
+            Note.Id(account.accountId, it)
+        }, result.replyId)
+        Assertions.assertEquals(noteDTO.renoteId?.let {
+            Note.Id(account.accountId, it)
+        }, result.renoteId)
+        Assertions.assertEquals(noteDTO.cw, result.cw)
+        Assertions.assertEquals(noteDTO.text, result.text)
+        Assertions.assertEquals(false, (result.type as Note.Type.Misskey).isRequireNyaize)
+    }
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -69,7 +69,9 @@ open class PlaneNoteViewData(
         instanceEmojis = emojiRepository.getAndConvertToMap(account.getHost()),
         userHost = toShowNote.user
             .host,
-        accountHost = account.getHost()
+        accountHost = account.getHost(),
+        isRequireProcessNyaize = (toShowNote.note.type as? Note.Type.Misskey)?.isRequireNyaize
+            ?: false
     )
 
     //true　折り畳み
@@ -85,8 +87,12 @@ open class PlaneNoteViewData(
     )
 
 
-    val textNode =
-        getTextType(account, toShowNote, emojiRepository.getAndConvertToMap(account.getHost()))
+    val textNode = getTextType(
+        account,
+        toShowNote,
+        emojiRepository.getAndConvertToMap(account.getHost()),
+        (toShowNote.note.type as? Note.Type.Misskey)?.isRequireNyaize ?: false
+    )
 
     val translateState: StateFlow<ResultState<Translation?>?> =
         noteTranslationStore.state(toShowNote.note.id).stateIn(
@@ -159,7 +165,10 @@ open class PlaneNoteViewData(
 
     val subNoteAvatarUrl = subNote?.user?.avatarUrl
     val subNoteTextNode = subNote?.let {
-        getTextType(account, it, emojiRepository.getAndConvertToMap(account.getHost()))
+        getTextType(
+            account, it, emojiRepository.getAndConvertToMap(account.getHost()),
+            (it.note.type as? Note.Type.Misskey)?.isRequireNyaize ?: false
+        )
     }
 
     val subCw = subNote?.note?.cw
@@ -168,7 +177,9 @@ open class PlaneNoteViewData(
         emojis = subNote?.note?.emojiNameMap,
         instanceEmojis = emojiRepository.getAndConvertToMap(account.getHost()),
         accountHost = account.getHost(),
-        userHost = subNote?.user?.host
+        userHost = subNote?.user?.host,
+        isRequireProcessNyaize = (toShowNote.note.type as? Note.Type.Misskey)?.isRequireNyaize
+            ?: false
     )
 
     //true　折り畳み

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/instance/InstanceInfoType.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/instance/InstanceInfoType.kt
@@ -79,4 +79,8 @@ sealed interface InstanceInfoType {
             is Firefish -> true
         }
     }
+
+    val isRequirePerformNyaizeFrontend: Boolean get() {
+        return this is Misskey && this.meta.getVersion() >= Version("2023.10.2")
+    }
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/note/Note.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/note/Note.kt
@@ -83,6 +83,7 @@ data class Note(
             val channel: SimpleChannelInfo? = null,
             val isAcceptingOnlyLikeReaction: Boolean = false,
             val isNotAcceptingSensitiveReaction: Boolean = false,
+            val isRequireNyaize: Boolean = false,
         ) : Type {
             data class SimpleChannelInfo(val id: Channel.Id, val name: String)
 


### PR DESCRIPTION
## やったこと
Misskey v2023.10.2からNyaize処理を表示時(フロントエンド)で行う必要性が出てくるようになったため、
その変更に対応するための実装を行なった。
擬似MFMのパーサー部分にNyaizeの変換処理の追加実装と、
Noteのモデル構造にNyaizeの処理の実効性の必要性の有無の状態を保持するようにした。
これに伴いObjectBoxのノートの構造を表すオブジェクトにフラグを持たせられるようにした。
Nyaizeの必要性の判定は非同期処理が実行可能な箇所かつ、変更をできる限り少なくできる箇所で実行したかったので、
NetworkDTOからModelに変換処理するレイヤーで実行するようにした。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号

Closed #1928

