### PR TITLE
Fix: リアクションピッカー上で絵文字を選択したときのリップルエフェクトの色合いを濃くして見やすくする

### DIFF
--- a/app/src/main/res/values-v23/themes.xml
+++ b/app/src/main/res/values-v23/themes.xml
@@ -40,6 +40,8 @@
         <item name="colorDotTabSelected">#575DAE</item>
         <item name="colorDotTabNormal">@color/colorItemNotSelected</item>
         <item name="android:windowLightStatusBar">true</item>
+
+        <item name="emojiPickerRippleColor">#5C000000</item>
     </style>
 
     <style name="AppThemeDark" parent="Theme.MaterialComponents.DayNight.NoActionBar">
@@ -71,5 +73,6 @@
         <item name="colorDotTabSelected">@color/colorDarkAccent</item>
         <item name="colorDotTabNormal">@color/colorDarkTextColor</item>
 
+        <item name="emojiPickerRippleColor">#66FFFFFF</item>
     </style>
 </resources>

--- a/app/src/main/res/values-v27/themes.xml
+++ b/app/src/main/res/values-v27/themes.xml
@@ -33,5 +33,7 @@
         <item name="colorDotTabSelected">#575DAE</item>
         <item name="colorDotTabNormal">@color/colorItemNotSelected</item>
         <item name="android:windowLightStatusBar">true</item>
+
+        <item name="emojiPickerRippleColor">#5C000000</item>
     </style>
 </resources>

--- a/modules/common_android_ui/src/main/res/layout/item_reaction_choice.xml
+++ b/modules/common_android_ui/src/main/res/layout/item_reaction_choice.xml
@@ -18,6 +18,8 @@
             reactionStringView="@{reactionStringPreview}"
             reaction="@{reaction}"
             android:onClick="@{ ()-> reactionSelection.selectReaction(reaction) }"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:theme="@style/EmojiPickerLayoutStyle"
             >
         <ImageView
                 android:id="@+id/reactionImagePreview"

--- a/modules/common_resource/src/main/res/values/styles.xml
+++ b/modules/common_resource/src/main/res/values/styles.xml
@@ -25,6 +25,7 @@
         <attr name="colorDotTabNormal" format="color" />
         <attr name="colorDotTabSelected" format="color" />
 
+        <attr name="emojiPickerRippleColor" format="color" />
     </declare-styleable>
     <!-- Base application theme. -->
 
@@ -74,5 +75,9 @@
         <item name="elevation">4dp</item>
         <item name="android:elevation">4dp</item>
 
+    </style>
+
+    <style name="EmojiPickerLayoutStyle">
+        <item name="colorControlHighlight">?attr/emojiPickerRippleColor</item>
     </style>
 </resources>

--- a/modules/common_resource/src/main/res/values/themes.xml
+++ b/modules/common_resource/src/main/res/values/themes.xml
@@ -30,6 +30,8 @@
 
         <item name="colorDotTabSelected">#575DAE</item>
         <item name="colorDotTabNormal">@color/colorItemNotSelected</item>
+
+        <item name="emojiPickerRippleColor">#5C000000</item>
     </style>
 
     <style name="AppTheme.NoActionBar">
@@ -71,6 +73,8 @@
         <item name="textInputStyle">@style/TextInputLayoutStyle</item>
         <item name="colorDotTabSelected">@color/colorDarkAccent</item>
         <item name="colorDotTabNormal">@color/colorDarkTextColor</item>
+
+        <item name="emojiPickerRippleColor">#66FFFFFF</item>
     </style>
 
     <style name="AppThemeBlack" parent="AppThemeDark">

--- a/modules/features/note/src/main/res/layout/item_emoji_choice.xml
+++ b/modules/features/note/src/main/res/layout/item_emoji_choice.xml
@@ -8,6 +8,7 @@
             android:padding="4dp"
             android:layout_margin="8dp"
             android:background="?attr/selectableItemBackgroundBorderless"
+            android:theme="@style/EmojiPickerLayoutStyle"
             >
         <ImageView
                 android:id="@+id/reactionImagePreview"


### PR DESCRIPTION
## やったこと
リアクションピッカーに表示されている絵文字をタップした際に発生する波紋エフェクトの濃さを変更しました。
波紋の色合いを若干濃くし、視認性の改善を図っています。

## 動作確認
ビルドしたアプリを端末にインストールし、実際に動作確認

## スクリーンショット(任意)
![Screenshot_20231026-091538](https://github.com/pantasystem/Milktea/assets/46447427/c039af54-f439-4ec5-b5da-e25f2621bcf8)
![Screenshot_20231026-091616](https://github.com/pantasystem/Milktea/assets/46447427/8fbaefde-674c-499e-8efb-be83fe21ea4a)

## 備考
自前のスマホしか実機がなかったため、他端末ではどのように表示されるのかまでは確認できていません…
他端末では対応前から視認性は十分で、この対応により更に濃くなって逆効果になる…などありましたら、お手数ですがcloseいただけると幸いです。

## Issue番号
-

