### PR TITLE
Fix: アプリ内から正常に表示できないAPNGを表示できるようにする

### DIFF
--- a/modules/common/build.gradle
+++ b/modules/common/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     implementation libs.glide.glide
     kapt libs.glide.compiler
     implementation "com.google.accompanist:accompanist-glide:0.14.0"
-    implementation 'com.github.penfeizhou.android.animation:apng:2.23.0'
+    implementation 'com.github.penfeizhou.android.animation:apng:2.24.0'
     implementation 'com.caverock:androidsvg-aar:1.4'
     implementation libs.okhttp3.logging.inspector
 

--- a/modules/common/src/main/java/net/pantasystem/milktea/common/glide/MiGlideModule.kt
+++ b/modules/common/src/main/java/net/pantasystem/milktea/common/glide/MiGlideModule.kt
@@ -25,10 +25,9 @@ import java.nio.ByteBuffer
 class MiGlideModule : AppGlideModule(){
 
     override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
-        val decoder = ByteBufferApngDecoder()
         registry
-            .prepend(InputStream::class.java, FrameSeqDecoder::class.java, StreamApngDecoder(decoder))
-            .prepend(ByteBuffer::class.java, FrameSeqDecoder::class.java, decoder)
+            .prepend(InputStream::class.java, FrameSeqDecoder::class.java, StreamApngDecoder())
+            .prepend(ByteBuffer::class.java, FrameSeqDecoder::class.java, ByteBufferApngDecoder())
             .register(FrameSeqDecoder::class.java, Drawable::class.java, FrameSeqDecoderDrawableTranscoder())
             .register(FrameSeqDecoder::class.java, Bitmap::class.java, FrameSeqDecoderBitmapTranscoder(glide))
             .register(SVG::class.java, BitmapDrawable::class.java, SvgBitmapTransCoder(context))

--- a/modules/common/src/main/java/net/pantasystem/milktea/common/glide/apng/ApngDecoder.kt
+++ b/modules/common/src/main/java/net/pantasystem/milktea/common/glide/apng/ApngDecoder.kt
@@ -50,6 +50,8 @@ object ApngDecoderDelegate {
         val sourceBytes = source.array()
         val iEndChunkPos = findIEndChunkPosition(sourceBytes)
 
+        // IENDチャンクより後にバイト配列がある状態でライブラリに渡すと例外が発生するため、
+        // IENDチャンクの終わる位置が終端となるよう切り詰めておく
         source.limit(iEndChunkPos + IENDBytes.size)
 
         val loader: Loader = object : ByteBufferLoader() {
@@ -67,31 +69,46 @@ object ApngDecoderDelegate {
     fun handles(source: ByteBuffer, options: Options): Boolean {
         val sourceBytes = source.array()
         if (!checkHeaderBytes(sourceBytes)) {
+            // PNGのヘッダではない
             return false
         }
 
         if (findIEndChunkPosition(sourceBytes) < 0) {
+            // IENDチャンクを持たない
             return false
         }
 
         return APNGParser.isAPNG(ByteBufferReader(source))
     }
 
+    /**
+     * [source]の先頭がPNGヘッダかどうかを確認する。
+     * PNGヘッダであった場合はtrue、そうでない場合はfalseを返却する。
+     */
     @JvmStatic
     private fun checkHeaderBytes(source: ByteArray): Boolean {
         val headerBytes = source.sliceArray(0..PNGHeaderBytes.size)
         return headerBytes.contentEquals(PNGHeaderBytes)
     }
 
+    /**
+     * [source]からIENDチャンクを検索し、IENDチャンクの先頭のインデックスを返却する。
+     * IENDチャンクが見つからない場合は-1を返却する。
+     */
     @JvmStatic
     private fun findIEndChunkPosition(source: ByteArray): Int {
         if (source.size < IENDBytes.size) {
             return -1
         }
 
+        // 計算量をなるべく抑えたいので、IENDチャンクのサイズを除外した位置から検索する。
+        // IENDチャンクが終端にある正常なファイルの場合はループせず1回で抜けるはず…
         val startPos = source.size - IENDBytes.size
         for (idx in (0..startPos).reversed()) {
             val curByte = source[idx]
+
+            // 現在のインデックスから取れるバイト値がIENDチャンクの先頭と合致していた場合は、
+            // その位置からIENDチャンクと同じサイズ分だけ配列をスライスし、配列の中身が完全に一致するかを確認する
             if (curByte == IENDBytes[0]) {
                 val hitTestTargetBytes = source.sliceArray(idx until (idx + IENDBytes.size))
                 if (hitTestTargetBytes.contentEquals(IENDBytes)) {

--- a/modules/common/src/main/java/net/pantasystem/milktea/common/glide/apng/ApngDecoder.kt
+++ b/modules/common/src/main/java/net/pantasystem/milktea/common/glide/apng/ApngDecoder.kt
@@ -12,59 +12,115 @@ import com.github.penfeizhou.animation.loader.Loader
 import java.nio.ByteBuffer
 
 
-const val PNG: Long = 0x89504E47
-
-
 class ByteBufferApngDecoder : ResourceDecoder<ByteBuffer, FrameSeqDecoder<*, *>> {
-
-
     override fun decode(
         source: ByteBuffer,
         width: Int,
         height: Int,
         options: Options
     ): Resource<FrameSeqDecoder<*, *>> {
+        return ApngDecoderDelegate.decode(source, width, height, options)
+    }
+
+    override fun handles(source: ByteBuffer, options: Options): Boolean {
+        return ApngDecoderDelegate.handles(source, options)
+    }
+}
+
+object ApngDecoderDelegate {
+    @JvmStatic
+    private val PNGHeaderBytes =
+        listOf(0x89, 0x50, 0x4E, 0x47)
+            .map { it.toByte() }
+            .toByteArray()
+
+    @JvmStatic
+    private val IENDBytes =
+        listOf(0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82)
+            .map { it.toByte() }
+            .toByteArray()
+
+    @JvmStatic
+    fun decode(
+        source: ByteBuffer,
+        width: Int,
+        height: Int,
+        options: Options
+    ): Resource<FrameSeqDecoder<*, *>> {
+        val sourceBytes = source.array()
+        val iEndChunkPos = findIEndChunkPosition(sourceBytes)
+
+        source.limit(iEndChunkPos + IENDBytes.size)
+
         val loader: Loader = object : ByteBufferLoader() {
             override fun getByteBuffer(): ByteBuffer {
                 source.position(0)
                 return source
             }
         }
+
         val decoder = APNGDecoder(loader, null)
         return FrameSeqDecoderResource(decoder, source.limit())
     }
 
-    override fun handles(source: ByteBuffer, options: Options): Boolean {
-        val byteBufferArray = ByteArray(8)
-        source.get(byteBufferArray, 0, 4)
-        val header = ByteBuffer.wrap(byteBufferArray).long ushr 32
-        if (header != PNG) {
+    @JvmStatic
+    fun handles(source: ByteBuffer, options: Options): Boolean {
+        val sourceBytes = source.array()
+        if (!checkHeaderBytes(sourceBytes)) {
+            return false
+        }
+
+        if (findIEndChunkPosition(sourceBytes) < 0) {
             return false
         }
 
         return APNGParser.isAPNG(ByteBufferReader(source))
-
     }
 
-    private class FrameSeqDecoderResource(
-        private val decoder: FrameSeqDecoder<*, *>,
-        private val size: Int
-    ) : Resource<FrameSeqDecoder<*, *>> {
-        override fun getResourceClass(): Class<FrameSeqDecoder<*, *>> {
-            return FrameSeqDecoder::class.java
-        }
-
-        override fun get(): FrameSeqDecoder<*, *> {
-            return decoder
-        }
-
-        override fun getSize(): Int {
-            return size
-        }
-
-        override fun recycle() {
-            decoder.stop()
-        }
+    @JvmStatic
+    private fun checkHeaderBytes(source: ByteArray): Boolean {
+        val headerBytes = source.sliceArray(0..PNGHeaderBytes.size)
+        return headerBytes.contentEquals(PNGHeaderBytes)
     }
 
+    @JvmStatic
+    private fun findIEndChunkPosition(source: ByteArray): Int {
+        if (source.size < IENDBytes.size) {
+            return -1
+        }
+
+        val startPos = source.size - IENDBytes.size
+        for (idx in (0..startPos).reversed()) {
+            val curByte = source[idx]
+            if (curByte == IENDBytes[0]) {
+                val hitTestTargetBytes = source.sliceArray(idx until (idx + IENDBytes.size))
+                if (hitTestTargetBytes.contentEquals(IENDBytes)) {
+                    return idx
+                }
+            }
+        }
+
+        return -1
+    }
+}
+
+private class FrameSeqDecoderResource(
+    private val decoder: FrameSeqDecoder<*, *>,
+    private val size: Int
+) : Resource<FrameSeqDecoder<*, *>> {
+    override fun getResourceClass(): Class<FrameSeqDecoder<*, *>> {
+        return FrameSeqDecoder::class.java
+    }
+
+    override fun get(): FrameSeqDecoder<*, *> {
+        return decoder
+    }
+
+    override fun getSize(): Int {
+        return size
+    }
+
+    override fun recycle() {
+        decoder.stop()
+    }
 }

--- a/modules/common/src/main/java/net/pantasystem/milktea/common/glide/apng/StreamApngDecoder.kt
+++ b/modules/common/src/main/java/net/pantasystem/milktea/common/glide/apng/StreamApngDecoder.kt
@@ -3,56 +3,39 @@ package net.pantasystem.milktea.common.glide.apng
 import com.bumptech.glide.load.Options
 import com.bumptech.glide.load.ResourceDecoder
 import com.bumptech.glide.load.engine.Resource
-import com.github.penfeizhou.animation.apng.decode.APNGParser
 import com.github.penfeizhou.animation.decode.FrameSeqDecoder
-import com.github.penfeizhou.animation.io.StreamReader
 import java.io.ByteArrayOutputStream
-import java.io.IOException
 import java.io.InputStream
 import java.nio.ByteBuffer
 
-class StreamApngDecoder(
-    val byteBufferApngDecoder: ByteBufferApngDecoder,
-) : ResourceDecoder<InputStream, FrameSeqDecoder<*, *>> {
+class StreamApngDecoder : ResourceDecoder<InputStream, FrameSeqDecoder<*, *>> {
+    companion object {
+        private const val BUFFER_SIZE = 16384
+    }
+
     override fun decode(
         source: InputStream,
         width: Int,
         height: Int,
         options: Options,
     ): Resource<FrameSeqDecoder<*, *>>? {
-        val data = inputStreamToBytes(source) ?: return null
-        val byteBuffer = ByteBuffer.wrap(data)
-        return byteBufferApngDecoder.decode(byteBuffer, width, height, options)
+        val sourceBuffer = inputStreamToByteBuffer(source) ?: return null
+        return ApngDecoderDelegate.decode(sourceBuffer, width, height, options)
     }
 
     override fun handles(source: InputStream, options: Options): Boolean {
-        val headerBytes = ByteArray(8)
-        val bytesRead = source.read(headerBytes)
-        // ファイルが8バイト未満の場合、それは有効なPNGではない
-        if (bytesRead < 8) {
-            return false
-        }
-
-        val header = ByteBuffer.wrap(headerBytes).long ushr 32
-        if (header != PNG) {
-            return false
-        }
-        return APNGParser.isAPNG(StreamReader(source))
+        val sourceBuffer = inputStreamToByteBuffer(source) ?: return false
+        return ApngDecoderDelegate.handles(sourceBuffer, options)
     }
 
-    private fun inputStreamToBytes(`is`: InputStream): ByteArray? {
-        val bufferSize = 16384
-        val buffer = ByteArrayOutputStream(bufferSize)
-        try {
-            var nRead: Int
-            val data = ByteArray(bufferSize)
-            while (`is`.read(data).also { nRead = it } != -1) {
-                buffer.write(data, 0, nRead)
+    private fun inputStreamToByteBuffer(inputStream: InputStream): ByteBuffer? {
+        val result = runCatching {
+            ByteArrayOutputStream(BUFFER_SIZE).use {
+                inputStream.copyTo(it)
+                it.toByteArray()
             }
-            buffer.flush()
-        } catch (e: IOException) {
-            return null
         }
-        return buffer.toByteArray()
+
+        return result.getOrNull()?.let { ByteBuffer.wrap(it) }
     }
 }

--- a/modules/common_android/build.gradle
+++ b/modules/common_android/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     //glide
     kapt libs.glide.compiler
     implementation "com.google.accompanist:accompanist-glide:0.14.0"
-    implementation 'com.github.penfeizhou.android.animation:apng:2.23.0'
+    implementation 'com.github.penfeizhou.android.animation:apng:2.24.0'
     implementation 'com.caverock:androidsvg-aar:1.4'
     implementation libs.kotlin.datetime
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -57,7 +57,7 @@ dependencyResolutionManagement {
             library('glide-glide', 'com.github.bumptech.glide:glide:4.14.2')
             library('glide-compiler', 'com.github.bumptech.glide:compiler:4.14.2')
             library('accompanist-glide', 'com.google.accompanist:accompanist-glide:0.14.0')
-            library('animation-apng', 'com.github.penfeizhou.android.animation:apng:2.23.0')
+            library('animation-apng', 'com.github.penfeizhou.android.animation:apng:2.24.0')
 
             library('wada811-databinding', 'com.github.wada811:DataBinding-ktx:5.0.2')
 


### PR DESCRIPTION
## やったこと
https://github.com/pantasystem/Milktea/issues/461 について対応しました。

- com.github.penfeizhou.android.animation:apng（以降、apngと表記）のバージョンを2.23.0→2.24.0に
- apng側へ画像のバイト配列を渡す前にIENDチャンクより後ろを切り捨てるように処理を追加（理由はissue参照）

## 動作確認
アプリを端末にインストールし、リアクションピッカーおよびTLから表示確認

## スクリーンショット(任意)
※対応前
![Polish_20231027_171848139](https://github.com/pantasystem/Milktea/assets/46447427/4a69947c-b2c9-430f-b965-4b050943e7ae)

※対応後
![Polish_20231027_171816539](https://github.com/pantasystem/Milktea/assets/46447427/899db4c1-2247-46c2-b2bd-df597a5c0266)


## 備考
issueに記載の通り、現象を完全に解決できるものではありません。あくまで軽減措置となります。
- 問題の起こるPNGの表示が出来るようになるが、アニメーションは出来ない原因不明）
- 画像バイト配列の末尾からIENDチャンクを無理やり線形探索しているため、わずかにパフォーマンスが落ちる

## Issue番号
https://github.com/pantasystem/Milktea/issues/461


