### PR TITLE
長すぎるカスタム絵文字を表示しようとするとクラッシュする不具合を修正

### DIFF
--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
@@ -340,14 +340,26 @@ object MFMDecorator {
                     null -> height
                     else -> height * aspectRatio
                 }
+                val windowWidthSize = textView.resources.displayMetrics.widthPixels
+                val finalEmojiWidth: Int
+                val finalEmojiHeight: Int
+                if ((width * customEmojiScale).toInt() > windowWidthSize && windowWidthSize > 0) {
+                    val scale = (windowWidthSize.toFloat() / (width * customEmojiScale))
+                    finalEmojiWidth = windowWidthSize
+                    finalEmojiHeight = (height * customEmojiScale * scale).toInt()
+                } else {
+                    finalEmojiWidth = (width * customEmojiScale).toInt()
+                    finalEmojiHeight = (height * customEmojiScale).toInt()
+                }
+
                 GlideApp.with(textView)
                     .load(emojiElement.emoji.cachePath)
                     .error(
                         GlideApp.with(textView)
                             .load(emojiElement.emoji.url ?: emojiElement.emoji.uri)
-                            .override((width * customEmojiScale).toInt(), (height * customEmojiScale).toInt())
+                            .override(finalEmojiWidth, finalEmojiHeight)
                     )
-                    .override((width * customEmojiScale).toInt(), (height * customEmojiScale).toInt())
+                    .override(finalEmojiWidth, finalEmojiHeight)
                     .into(emojiSpan.target)
             }
         }


### PR DESCRIPTION
## やったこと
長すぎるカスタム絵文字をTextView上に表示しようとするとクラッシュする不具合を修正しました。
原因としてはスケールする時に画像のサイズが大きくなってしまうのが原因でした。
なので、画像のサイズが画面のサイズより大きく読み込まれないように制限することで解決しました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1932



