### PR TITLE
feat: ユーザのプロフィールとノートの名前欄横にロールバッジを出す機能を追加

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/accounts/MastodonAccountDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/accounts/MastodonAccountDTO.kt
@@ -100,6 +100,7 @@ data class MastodonAccountDTO(
                 description = note,
             ),
             related = related,
+            badgeRoles = emptyList(),
         )
     }
 }

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/users/UserDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/users/UserDTO.kt
@@ -121,6 +121,9 @@ data class UserDTO(
 
     @SerialName("notify")
     val notifyState: String? = null,
+
+    @SerialName("badgeRoles")
+    val badgeRoles: List<BadgeRoleDTO>? = null
 ) : Serializable {
 
     @kotlinx.serialization.Serializable
@@ -161,4 +164,15 @@ data class UserDTO(
         @SerialName("value")
         val value: String)
 
+    @kotlinx.serialization.Serializable
+    data class BadgeRoleDTO(
+        @SerialName("name")
+        val name: String,
+
+        @SerialName("iconUrl")
+        val iconUrl: String?,
+
+        @SerialName("displayOrder")
+        val displayOrder: Int,
+    )
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/converters/UserDTOEntityConverter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/converters/UserDTOEntityConverter.kt
@@ -60,6 +60,22 @@ class UserDTOEntityConverter @Inject constructor(
             it.name to it.host to it.url to it.uri
         }
 
+        val badgeRoles = if (!userDTO.badgeRoles.isNullOrEmpty()) {
+            userDTO.badgeRoles!!.map { role ->
+                val iconUrl = role.iconUrl?.let {
+                    imageCacheRepository.save(it)
+                }
+
+                User.BadgeRole(
+                    name = role.name,
+                    iconUri = iconUrl?.cachePath,
+                    displayOrder = role.displayOrder
+                )
+            }
+        } else {
+            emptyList()
+        }
+
         if (isDetail) {
             return User.Detail(
                 id = User.Id(account.accountId, userDTO.id),
@@ -105,7 +121,8 @@ class UserDTOEntityConverter @Inject constructor(
                     isNotify = userDTO.notifyState?.let {
                         userDTO.notifyState == "normal"
                     }
-                )
+                ),
+                badgeRoles = badgeRoles
             )
         } else {
             return User.Simple(
@@ -120,7 +137,8 @@ class UserDTOEntityConverter @Inject constructor(
                 nickname = null,
                 isSameHost = userDTO.host == null,
                 instance = instanceInfo,
-                avatarBlurhash = userDTO.avatarBlurhash
+                avatarBlurhash = userDTO.avatarBlurhash,
+                badgeRoles = badgeRoles
             )
         }
     }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/DbModule.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/DbModule.kt
@@ -45,6 +45,7 @@ object DbModule {
             .addMigrations(MIGRATION_8_10)
             .addMigrations(MIGRATION_10_11)
             .addMigrations(MIGRATION_51_52)
+            .addMigrations(MIGRATION_56_57)
             .build()
     }
 

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/DataBase.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/DataBase.kt
@@ -92,6 +92,7 @@ import net.pantasystem.milktea.data.infrastructure.user.renote.mute.db.RenoteMut
         UserListRecord::class,
         UserListMemberIdRecord::class,
         InstanceInfoRecord::class,
+        BadgeRoleRecord::class,
 
         SearchHistoryRecord::class,
         UserInfoStateRecord::class,
@@ -116,7 +117,7 @@ import net.pantasystem.milktea.data.infrastructure.user.renote.mute.db.RenoteMut
         CustomEmojiRecord::class,
         CustomEmojiAliasRecord::class,
     ],
-    version = 56,
+    version = 57,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 11, to = 12),
@@ -163,6 +164,7 @@ import net.pantasystem.milktea.data.infrastructure.user.renote.mute.db.RenoteMut
         AutoMigration(from = 53, to = 54),
         AutoMigration(from = 54, to = 55),
         AutoMigration(from = 55, to = 56),
+        AutoMigration(from = 56, to = 57),
     ],
     views = [UserView::class, GroupMemberView::class, UserListMemberView::class]
 )

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/Migrations.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/Migrations.kt
@@ -115,3 +115,10 @@ val MIGRATION_51_52 = object : Migration(51, 52) {
         database.execSQL("DROP TABLE IF EXISTS 'emoji_table'")
     }
 }
+
+val MIGRATION_56_57 = object : Migration(56, 57) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("CREATE TABLE IF NOT EXISTS 'user_badge_role' ('name' TEXT NOT NULL, 'iconUrl' TEXT NULL, 'displayOrder' INTEGER NOT NULL, 'userId' INTEGER NOT NULL, 'id' INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)")
+        database.execSQL("CREATE INDEX IF NOT EXISTS 'index_user_badge_role' ON 'user_badge_role' ('userId')")
+    }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/MediatorUserDataSource.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/MediatorUserDataSource.kt
@@ -16,6 +16,7 @@ import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.common.collection.LRUCache
 import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common_android.hilt.IODispatcher
+import net.pantasystem.milktea.data.infrastructure.user.db.BadgeRoleRecord
 import net.pantasystem.milktea.data.infrastructure.user.db.PinnedNoteIdRecord
 import net.pantasystem.milktea.data.infrastructure.user.db.UserDao
 import net.pantasystem.milktea.data.infrastructure.user.db.UserEmojiRecord
@@ -24,6 +25,7 @@ import net.pantasystem.milktea.data.infrastructure.user.db.UserInstanceInfoRecor
 import net.pantasystem.milktea.data.infrastructure.user.db.UserProfileFieldRecord
 import net.pantasystem.milktea.data.infrastructure.user.db.UserRecord
 import net.pantasystem.milktea.data.infrastructure.user.db.UserRelatedStateRecord
+import net.pantasystem.milktea.data.infrastructure.user.db.isEqualToBadgeRoleModels
 import net.pantasystem.milktea.data.infrastructure.user.db.isEqualToModels
 import net.pantasystem.milktea.model.AddResult
 import net.pantasystem.milktea.model.user.Acct
@@ -140,6 +142,22 @@ class MediatorUserDataSource @Inject constructor(
                             url = it.url,
                             aspectRatio = it.aspectRatio,
                             cachePath = it.cachePath
+                        )
+                    }
+                )
+            }
+
+            if (!record?.badgeRoles.isEqualToBadgeRoleModels(user.badgeRoles)) {
+                if (record != null) {
+                    userDao.detachAllUserBadgeRoles(dbId)
+                }
+                userDao.insertUserBadgeRoles(
+                    user.badgeRoles.map {
+                        BadgeRoleRecord(
+                            userId = dbId,
+                            name = it.name,
+                            iconUrl = it.iconUri,
+                            displayOrder = it.displayOrder,
                         )
                     }
                 )

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/db/UserDao.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/db/UserDao.kt
@@ -29,6 +29,9 @@ abstract class UserDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract suspend fun insertUserProfileFields(fields: List<UserProfileFieldRecord>): List<Long>
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun insertUserBadgeRoles(fields: List<BadgeRoleRecord>): List<Long>
+
     @Query("delete from pinned_note_id where userId = :userId")
     abstract suspend fun detachAllPinnedNoteIds(userId: Long)
 
@@ -37,6 +40,9 @@ abstract class UserDao {
 
     @Query("delete from user_profile_field where userId = :userId")
     abstract suspend fun detachUserFields(userId: Long)
+
+    @Query("delete from user_badge_role where userId = :userId")
+    abstract suspend fun detachAllUserBadgeRoles(userId: Long)
 
     @Update
     abstract suspend fun update(user: UserRecord)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/db/UserRecord.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/db/UserRecord.kt
@@ -333,6 +333,18 @@ fun List<UserEmojiRecord>?.isEqualToModels(models: List<CustomEmoji>): Boolean {
     }
 }
 
+fun List<BadgeRoleRecord>?.isEqualToBadgeRoleModels(models: List<User.BadgeRole>): Boolean {
+    if (this == null && models.isEmpty()) return true
+    if (this == null) return false
+    if (size != models.size) return false
+    val records = this.toSet()
+    return models.all {  model ->
+        records.any { record ->
+            record.isEqualToModel(model)
+        }
+    }
+}
+
 @Entity(
     tableName = "user_instance_info",
     foreignKeys = [
@@ -469,6 +481,44 @@ data class UserView(
     val avatarBlurhash: String?
 )
 
+@Entity(
+    tableName = "user_badge_role",
+    foreignKeys = [
+        ForeignKey(
+            parentColumns = ["id"],
+            childColumns = ["userId"],
+            entity = UserRecord::class,
+            onUpdate = ForeignKey.CASCADE,
+            onDelete = ForeignKey.CASCADE,
+        )
+    ],
+    indices = [
+        Index("userId")
+    ]
+)
+data class BadgeRoleRecord(
+    @ColumnInfo("name")
+    val name: String,
+
+    @ColumnInfo("iconUrl")
+    val iconUrl: String?,
+
+    @ColumnInfo("displayOrder")
+    val displayOrder: Int,
+
+    @ColumnInfo("userId")
+    val userId: Long,
+
+    @ColumnInfo(name = "id")
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+) {
+    fun isEqualToModel(model: User.BadgeRole): Boolean {
+        return name == model.name &&
+                iconUrl == model.iconUri &&
+                displayOrder == model.displayOrder
+    }
+}
+
 interface HasUserModel {
     fun toModel(): User
 }
@@ -485,6 +535,11 @@ data class UserSimpleRelated(
         entityColumn = "userId"
     )
     val instance: UserInstanceInfoRecord?,
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "userId"
+    )
+    val badgeRoles: List<BadgeRoleRecord>,
 ) : HasUserModel {
     override fun toModel(): User.Simple {
         val instanceInfo = instance?.let {
@@ -520,6 +575,13 @@ data class UserSimpleRelated(
             },
             instance = instanceInfo,
             avatarBlurhash = user.avatarBlurhash,
+            badgeRoles = badgeRoles.map {
+                User.BadgeRole(
+                    name = it.name,
+                    iconUri = it.iconUrl,
+                    displayOrder = it.displayOrder,
+                )
+            }
         )
     }
 }
@@ -561,8 +623,13 @@ data class UserRelated(
         parentColumn = "id",
         entityColumn = "userId",
     )
-    val fields: List<UserProfileFieldRecord>?
+    val fields: List<UserProfileFieldRecord>?,
 
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "userId"
+    )
+    val badgeRoles: List<BadgeRoleRecord>,
 ) : HasUserModel {
     override fun toModel(): User {
         val instanceInfo = instance?.let {
@@ -599,6 +666,13 @@ data class UserRelated(
                 },
                 instance = instanceInfo,
                 avatarBlurhash = user.avatarBlurhash,
+                badgeRoles = badgeRoles.map {
+                    User.BadgeRole(
+                        name = it.name,
+                        iconUri = it.iconUrl,
+                        displayOrder = it.displayOrder,
+                    )
+                }
             )
         } else {
             return User.Detail(
@@ -655,6 +729,13 @@ data class UserRelated(
                         hasPendingFollowRequestFromYou = related.hasPendingFollowRequestFromYou,
                         hasPendingFollowRequestToYou = related.hasPendingFollowRequestToYou,
                         isNotify = related.isNotify ?: false,
+                    )
+                },
+                badgeRoles = badgeRoles.map {
+                    User.BadgeRole(
+                        name = it.name,
+                        iconUri = it.iconUrl,
+                        displayOrder = it.displayOrder,
                     )
                 }
             )

--- a/modules/features/note/build.gradle
+++ b/modules/features/note/build.gradle
@@ -98,6 +98,7 @@ dependencies {
     implementation libs.accompanist.pager
     implementation libs.accompanist.pager.indicators
     implementation libs.coil.compose
+    implementation libs.coil.svg
     implementation libs.compose.constraintlayout
 
     // hilt

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineListAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineListAdapter.kt
@@ -20,6 +20,7 @@ import com.bumptech.glide.RequestBuilder
 import com.bumptech.glide.integration.recyclerview.RecyclerViewPreloader
 import com.bumptech.glide.util.FixedPreloadSizeProvider
 import com.google.android.flexbox.FlexboxLayout
+import com.google.android.material.composethemeadapter.MdcTheme
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -34,6 +35,8 @@ import net.pantasystem.milktea.note.databinding.ItemTimelineEmptyBinding
 import net.pantasystem.milktea.note.databinding.ItemTimelineErrorBinding
 import net.pantasystem.milktea.note.reaction.ReactionViewData
 import net.pantasystem.milktea.note.timeline.viewmodel.TimelineListItem
+import net.pantasystem.milktea.note.view.NoteBadgeRoleData
+import net.pantasystem.milktea.note.view.NoteBadgeRoles
 import net.pantasystem.milktea.note.view.NoteCardAction
 import net.pantasystem.milktea.note.view.NoteCardActionListenerAdapter
 import net.pantasystem.milktea.note.viewmodel.HasReplyToNoteViewData
@@ -186,7 +189,21 @@ class TimelineListAdapter(
         override fun onBind(note: PlaneNoteViewData) {
             binding.note = note
             binding.noteCardActionListener = noteCardActionListenerAdapter
-
+            binding.simpleNote.badgeRoles.apply {
+                setContent {
+                    MdcTheme {
+                        NoteBadgeRoles(
+                            badgeRoles = note.note.user.badgeRoles.map {
+                                NoteBadgeRoleData(
+                                    name = it.name,
+                                    iconUri = it.iconUri,
+                                    displayOrder = it.displayOrder
+                                )
+                            }
+                        )
+                    }
+                }
+            }
         }
 
 
@@ -209,9 +226,22 @@ class TimelineListAdapter(
         override fun onBind(note: PlaneNoteViewData) {
             if (note is HasReplyToNoteViewData) {
                 binding.hasReplyToNote = note
-
                 binding.noteCardActionListener = noteCardActionListenerAdapter
-
+                binding.simpleNote.badgeRoles.apply {
+                    setContent {
+                        MdcTheme {
+                            NoteBadgeRoles(
+                                badgeRoles = note.note.user.badgeRoles.map {
+                                    NoteBadgeRoleData(
+                                        name = it.name,
+                                        iconUri = it.iconUri,
+                                        displayOrder = it.displayOrder
+                                    )
+                                }
+                            )
+                        }
+                    }
+                }
             }
         }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/view/NoteBadgeRoleData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/view/NoteBadgeRoleData.kt
@@ -1,0 +1,68 @@
+package net.pantasystem.milktea.note.view
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import coil.decode.SvgDecoder
+import coil.request.ImageRequest
+
+private val defaultSvgDecoderFactory = SvgDecoder.Factory()
+
+@Composable
+fun NoteBadgeRoles(
+    badgeRoles: List<NoteBadgeRoleData>,
+    modifier: Modifier = Modifier,
+) {
+    val sortedBadgeRoles = badgeRoles
+        // アイコンなしは出しようがないので弾く
+        .filter { it.iconUri != null }
+        .sortedBy { it.displayOrder }
+
+    Surface {
+        Row(
+//            horizontalArrangement = Arrangement.spacedBy(2.dp),
+            modifier = modifier.fillMaxHeight()
+        ) {
+            for (it in sortedBadgeRoles) {
+                NoteBadgeRoleImage(
+                    data = it,
+                    modifier = Modifier.padding(1.dp) // 名前欄とxml側で高さを揃えているが、それでも気持ちデカイので調節
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun NoteBadgeRoleImage(
+    data: NoteBadgeRoleData,
+    modifier: Modifier = Modifier,
+) {
+    Image(
+        painter = rememberAsyncImagePainter(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(data.iconUri)
+                .decoderFactory(defaultSvgDecoderFactory)
+                .build(),
+        ),
+        contentDescription = data.name,
+        contentScale = ContentScale.FillHeight,
+        modifier = modifier.aspectRatio(1.0f)
+    )
+}
+
+data class NoteBadgeRoleData(
+    val name: String,
+    val iconUri: String?,
+    val displayOrder: Int,
+)

--- a/modules/features/note/src/main/res/layout/item_simple_note.xml
+++ b/modules/features/note/src/main/res/layout/item_simple_note.xml
@@ -82,10 +82,21 @@
             android:maxLines="1"
             android:textSize="@dimen/note_author_info_text_size"
             android:textStyle="italic"
-            app:layout_constraintEnd_toStartOf="@id/elapsedTime"
+            app:layout_constraintEnd_toStartOf="@id/badgeRoles"
             app:layout_constraintStart_toEndOf="@id/mainName"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="ユーザー名awefawefawefawefawefawefwaefwef" />
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/badgeRoles"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
+            android:layout_marginStart="4dp"
+            android:padding="1dp"
+            app:layout_constraintBottom_toBottomOf="@+id/subName"
+            app:layout_constraintEnd_toStartOf="@id/elapsedTime"
+            app:layout_constraintStart_toEndOf="@id/subName"
+            app:layout_constraintTop_toTopOf="@+id/subName" />
 
         <TextView
             android:id="@+id/elapsedTime"
@@ -96,7 +107,7 @@
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
             android:layout_marginStart="4dp"
-            android:layout_toEndOf="@id/subName"
+            android:layout_toEndOf="@id/badgeRoles"
             android:ellipsize="end"
 
             android:gravity="end"

--- a/modules/features/user/build.gradle
+++ b/modules/features/user/build.gradle
@@ -96,6 +96,7 @@ dependencies {
     implementation libs.accompanist.pager
     implementation libs.accompanist.pager.indicators
     implementation libs.coil.compose
+    implementation libs.coil.svg
     implementation libs.compose.constraintlayout
 
 

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/compose/SimpleUsers.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/compose/SimpleUsers.kt
@@ -94,6 +94,7 @@ fun PreviewItemSimpleUser() {
         isSameHost = true,
         instance = null,
         avatarBlurhash = null,
+        badgeRoles = emptyList(),
     ), onSelected = {}, accountHost = "misskey.io"
     )
 }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/followrequests/FollowRequestItem.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/followrequests/FollowRequestItem.kt
@@ -132,7 +132,8 @@ fun Preview_FollowRequestItem() {
             nickname = null,
             isSameHost = false,
             instance = null,
-            avatarBlurhash = null
+            avatarBlurhash = null,
+            badgeRoles = emptyList(),
         ), onAccept = {}, onReject = {}, onAvatarClicked = {}
     )
 }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/UserDetailActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/UserDetailActivity.kt
@@ -11,9 +11,12 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.core.app.TaskStackBuilder
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.*
+import com.google.android.material.composethemeadapter.MdcTheme
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
@@ -45,6 +48,8 @@ import net.pantasystem.milktea.user.databinding.ActivityUserDetailBinding
 import net.pantasystem.milktea.user.followlist.FollowFollowerActivity
 import net.pantasystem.milktea.user.nickname.EditNicknameDialog
 import net.pantasystem.milktea.user.profile.mute.SpecifyMuteExpiredAtDialog
+import net.pantasystem.milktea.user.profile.view.ProfileBadgeRoleData
+import net.pantasystem.milktea.user.profile.view.ProfileBadgeRoles
 import net.pantasystem.milktea.user.profile.viewmodel.UserDetailViewModel
 import net.pantasystem.milktea.user.qrshare.QRShareDialog
 import javax.inject.Inject
@@ -164,6 +169,24 @@ class UserDetailActivity : AppCompatActivity() {
         )
         binding.lifecycleOwner = this
         binding.userViewModel = mViewModel
+
+        binding.badgeRoles.apply {
+            setContent {
+                val userDetail by mViewModel.userState.collectAsState()
+                MdcTheme {
+                    ProfileBadgeRoles(
+                        (userDetail?.badgeRoles ?: emptyList()).map {
+                            ProfileBadgeRoleData(
+                                name = it.name,
+                                iconUri = it.iconUri,
+                                displayOrder = it.displayOrder
+                            )
+                        }
+                    )
+                }
+            }
+        }
+
         setSupportActionBar(binding.userDetailToolbar)
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/view/ProfileBadgeRoles.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/view/ProfileBadgeRoles.kt
@@ -1,0 +1,128 @@
+package net.pantasystem.milktea.user.profile.view
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.TextUnitType
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
+import coil.compose.rememberAsyncImagePainter
+import coil.decode.SvgDecoder
+import coil.request.ImageRequest
+
+private val defaultSvgDecoderFactory = SvgDecoder.Factory()
+
+@Composable
+fun ProfileBadgeRoles(
+    badgeRoles: List<ProfileBadgeRoleData>
+) {
+    val sortedBadgeRoles = badgeRoles.sortedBy { it.displayOrder }
+
+    Surface {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            for (it in sortedBadgeRoles) {
+                ProfileBadgeRole(it)
+            }
+        }
+    }
+}
+
+@Composable
+fun ProfileBadgeRole(
+    data: ProfileBadgeRoleData,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .border(
+                color = Color.LightGray,
+                width = 0.5.dp,
+                shape = RoundedCornerShape(4.dp)
+            )
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(2.dp)
+        ) {
+            ConstraintLayout {
+                val (image, text) = createRefs()
+
+                ProfileBadgeRoleImage(
+                    data = data,
+                    modifier = Modifier
+                        .constrainAs(image) {
+                            // startの位置だけ固定して、高さはラベルと合わせる
+                            top.linkTo(text.top)
+                            bottom.linkTo(text.bottom)
+                            start.linkTo(parent.start)
+
+                            width = Dimension.wrapContent
+                            height = Dimension.fillToConstraints
+                        }
+                        .padding(2.dp) // textと高さを揃えているが、それでも気持ちデカイので調節
+                )
+
+                ProfileBadgeRoleText(
+                    data = data,
+                    modifier = Modifier
+                        .constrainAs(text) {
+                            // startの位置だけ固定して、高さ・幅は中の文字列とフォントの高さにまかせる
+                            start.linkTo(image.end)
+
+                            width = Dimension.wrapContent
+                            height = Dimension.wrapContent
+                        }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ProfileBadgeRoleImage(data: ProfileBadgeRoleData, modifier: Modifier = Modifier) {
+    data.iconUri?.let {
+        Image(
+            painter = rememberAsyncImagePainter(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(data.iconUri)
+                    .decoderFactory(defaultSvgDecoderFactory)
+                    .build(),
+            ),
+            contentDescription = data.name,
+            modifier = modifier.aspectRatio(1.0f)
+        )
+    }
+}
+
+@Composable
+fun ProfileBadgeRoleText(data: ProfileBadgeRoleData, modifier: Modifier = Modifier) {
+    Text(
+        text = data.name,
+        fontSize = TextUnit(13F, TextUnitType.Sp),
+        modifier = modifier.wrapContentHeight()
+    )
+}
+
+data class ProfileBadgeRoleData(
+    val name: String,
+    val iconUri: String?,
+    val displayOrder: Int,
+)

--- a/modules/features/user/src/main/res/layout/activity_user_detail.xml
+++ b/modules/features/user/src/main/res/layout/activity_user_detail.xml
@@ -185,27 +185,37 @@
                             android:contentDescription="@string/change_nickname"
                             />
 
+                    <androidx.compose.ui.platform.ComposeView
+                        android:id="@+id/badgeRoles"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="16dp"
+                        android:layout_marginTop="8dp"
+                        android:layout_marginEnd="16dp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/subName" />
 
                     <TextView
-                            android:id="@+id/profileText"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_alignStart="@id/avatarIcon"
-                            app:sourceText="@{userViewModel.userState.info.description}"
-                            app:account="@{userViewModel.currentAccount}"
-                            app:host="@{userViewModel.userState.host}"
-                            app:emojis="@{userViewModel.userState.emojis}"
-                            tools:text="awoijfoiwaehfoaiwehfoiawjefoiawjefiojawioefjioawhfoiawehfoiawef"
-                            android:layout_marginEnd="16dp"
-                            android:layout_marginTop="8dp"
-                            android:visibility="@{userViewModel.userState.info.description == null ? View.GONE : View.VISIBLE}"
-                            app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toBottomOf="@id/subName"
-                            android:layout_marginStart="16dp"
-                            app:layout_constraintEnd_toEndOf="parent"
+                        android:id="@+id/profileText"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_alignStart="@id/avatarIcon"
+                        android:layout_marginStart="16dp"
+                        android:layout_marginTop="8dp"
+                        android:layout_marginEnd="16dp"
+                        android:visibility="@{userViewModel.userState.info.description == null ? View.GONE : View.VISIBLE}"
+                        app:account="@{userViewModel.currentAccount}"
+                        app:emojis="@{userViewModel.userState.emojis}"
+                        app:host="@{userViewModel.userState.host}"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/badgeRoles"
+                        app:sourceText="@{userViewModel.userState.info.description}"
+                        tools:text="awoijfoiwaehfoaiwehfoiawjefoiawjefiojawioefjioawhfoiawehfoiawef"
 
 
-                            />
+                        />
 
                     <TextView
                             android:layout_width="0dp"

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/User.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/User.kt
@@ -32,6 +32,7 @@ sealed interface User : Entity {
     val instance: InstanceInfo?
     val avatarBlurhash: String?
     val parsedResult: CustomEmojiParsedResult
+    val badgeRoles: List<BadgeRole>
 
 
     class Id(
@@ -79,7 +80,8 @@ sealed interface User : Entity {
         override val nickname: UserNickname?,
         override val isSameHost: Boolean,
         override val instance: InstanceInfo?,
-        override val avatarBlurhash: String?
+        override val avatarBlurhash: String?,
+        override val badgeRoles: List<BadgeRole>
     ) : User {
         companion object;
         override val parsedResult: CustomEmojiParsedResult = try {
@@ -104,6 +106,7 @@ sealed interface User : Entity {
         override val avatarBlurhash: String?,
         override val isSameHost: Boolean,
         override val instance: InstanceInfo?,
+        override val badgeRoles: List<BadgeRole>,
         val info: Info,
         val related: Related?,
     ) : User {
@@ -190,6 +193,12 @@ sealed interface User : Entity {
         val value: String,
     )
 
+    data class BadgeRole(
+        val name: String,
+        val iconUri: String?,
+        val displayOrder: Int,
+    )
+
     val displayUserName: String
         get() = "@" + this.userName + if (isSameHost) {
             ""
@@ -241,6 +250,7 @@ sealed interface User : Entity {
                     isPublicReactions = false,
                 ),
                 related = null,
+                badgeRoles = badgeRoles,
             )
         }
     }
@@ -263,6 +273,7 @@ fun User.Simple.Companion.make(
     isSameHost: Boolean? = null,
     instance: User.InstanceInfo? = null,
     avatarBlurhash: String? = null,
+    badgeRoles: List<User.BadgeRole> = emptyList(),
 ): User.Simple {
     return User.Simple(
         id,
@@ -276,7 +287,8 @@ fun User.Simple.Companion.make(
         nickname = nickname,
         isSameHost = isSameHost ?: false,
         instance = instance,
-        avatarBlurhash = avatarBlurhash
+        avatarBlurhash = avatarBlurhash,
+        badgeRoles = badgeRoles,
     )
 }
 
@@ -315,6 +327,7 @@ fun User.Detail.Companion.make(
     isPublicReactions: Boolean = false,
     avatarBlurhash: String? = null,
     isNotify: Boolean = false,
+    badgeRoles: List<User.BadgeRole> = emptyList(),
 ): User.Detail {
     return User.Detail(
         id,
@@ -353,6 +366,7 @@ fun User.Detail.Companion.make(
             hasPendingFollowRequestFromYou = hasPendingFollowRequestFromYou,
             hasPendingFollowRequestToYou = hasPendingFollowRequestToYou,
             isNotify = isNotify,
-        )
+        ),
+        badgeRoles = badgeRoles,
     )
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,6 +29,7 @@ dependencyResolutionManagement {
             library("accompanist-pager", "com.google.accompanist:accompanist-pager:0.14.0")
             library("accompanist-pager-indicators", "com.google.accompanist:accompanist-pager-indicators:0.14.0")
             library("coil-compose", "io.coil-kt:coil-compose:2.4.0")
+            library("coil-svg", "io.coil-kt:coil-svg:2.4.0")
             library("compose-constraintlayout", "androidx.constraintlayout:constraintlayout-compose:1.0.1")
 
             library("hilt-android", "com.google.dagger:hilt-android:2.45")


### PR DESCRIPTION
## やったこと
ユーザのプロフィール画面とノートに対し、ユーザに割り当てられたロールのアイコンを出すようにViewを追加しました。  
ただし、リプライ時のリプライ先ノートと引用リノートの引用された側ノートは対象外としています。時間表示も省かれていることから、画面表示の見通しのためにあえて削っているのかなと推測しました。

## 動作確認
端末上で表示確認

## スクリーンショット(任意)
<img width=50% src="https://github.com/pantasystem/Milktea/assets/46447427/220327e8-28a6-4ffe-98db-155f6c5ecd94" />
<img width=50% src="https://github.com/pantasystem/Milktea/assets/46447427/aadfe6ee-d61f-411b-b365-e0bd5d51ab29" />
<img width=50% src="https://github.com/pantasystem/Milktea/assets/46447427/526e365a-97cc-4b2e-9b5d-b7992098fb10" />
<img width=50% src="https://github.com/pantasystem/Milktea/assets/46447427/c28a8461-7ff7-4a30-873a-d20844b5969a" />


## 備考
すでにユーザ情報をDBに持っているため、それにあわせてロールの情報も持つようにDB定義を更新しています。
この機能リクエストが不要でしたら、お手数ですがcloseお願い致します。

## Issue番号
- 


