### PR TITLE
MediaLayoutのパフォーマンスを改善した

### DIFF
--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/MediaLayout.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/MediaLayout.kt
@@ -229,7 +229,11 @@ class MediaLayout : ViewGroup {
     class LayoutParams : ViewGroup.LayoutParams {
 
         constructor(c: Context, attrs: AttributeSet?) : super(c, attrs)
+
+        @Suppress("unused")
         constructor(width: Int, height: Int) : super(width, height)
+
+        @Suppress("unused")
         constructor(source: ViewGroup.LayoutParams?) : super(source)
 
         internal var isRight = false

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/MediaLayout.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/MediaLayout.kt
@@ -199,13 +199,13 @@ class MediaLayout : ViewGroup {
             val childHeight = params.measuredHeight
             val childTop = (i / 2) * childHeight
             val childLeft = if (isRight) {
-                width - _childWidth
+                width - params.measuredWidth
             } else {
                 0
             }
 
             val childBottom = childTop + childHeight
-            val childRight = childLeft + _childWidth
+            val childRight = childLeft + params.measuredWidth
 
             val hasRightItem = !isOddView && !isLast && _visibleChildItemCount > 1
             val hasTopItem = i >= 2

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/MediaLayout.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/MediaLayout.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.annotation.AttrRes
 import androidx.annotation.StyleRes
 import androidx.core.view.children
-import androidx.core.view.isVisible
 import net.pantasystem.milktea.common_android.R
 import kotlin.math.max
 import kotlin.math.min
@@ -67,7 +66,7 @@ class MediaLayout : ViewGroup {
 
     private var spaceMargin = 8
     private var _visibleChildItemCount = 0
-    private var _visibleChildren = listOf<View>()
+    private var _visibleChildren = mutableListOf<View>()
     private var _isOddVisibleItemCount = false
 
     private var _height: Int = 0
@@ -104,10 +103,18 @@ class MediaLayout : ViewGroup {
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-        _visibleChildren = children.filter { it.isVisible }.toList()
+        _visibleChildren.clear()
+        for (v in children) {
+            if (v.visibility == View.VISIBLE) {
+                _visibleChildren.add(v)
+            }
+        }
         _visibleChildItemCount = _visibleChildren.size
         _isOddVisibleItemCount = _visibleChildItemCount % 2 == 1
-        if (_visibleChildItemCount == 0 || _suspendLayout) {
+        if (_suspendLayout) {
+            return
+        }
+        if (_visibleChildItemCount == 0) {
             _height = 0
             setMeasuredDimension(0, 0)
             return

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/MediaLayout.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/MediaLayout.kt
@@ -93,8 +93,8 @@ class MediaLayout : ViewGroup {
             attrs, R.styleable.MediaLayout, defStyleAttr, defStyleRes
         )
         a.apply {
-            val spaceSize = getResourceId(R.styleable.MediaLayout_spaceSize, 8)
-            spaceMargin = if (spaceSize != 0) spaceSize / 2 else 0
+            val spaceSize = getDimensionPixelSize(R.styleable.MediaLayout_spaceSize, 8)
+            spaceMargin = spaceSize / 2
         }
 
         a.recycle()

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/MediaLayout.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/MediaLayout.kt
@@ -66,7 +66,7 @@ class MediaLayout : ViewGroup {
 
     private var spaceMargin = 8
     private var _visibleChildItemCount = 0
-    private var _visibleChildren = mutableListOf<View>()
+    private var _visibleChildren = ArrayList<View>(16)
     private var _isOddVisibleItemCount = false
 
     private var _height: Int = 0

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/MediaLayout.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/MediaLayout.kt
@@ -159,12 +159,10 @@ class MediaLayout : ViewGroup {
                 _visibleChildItemCount == 3 && i == 1
             }
 
-            if (params.measuredWidth != _childWidth || params.measuredHeight != childHeight) {
-                child.measure(
-                    MeasureSpec.makeMeasureSpec(_childWidth, MeasureSpec.EXACTLY),
-                    MeasureSpec.makeMeasureSpec(childHeight, MeasureSpec.EXACTLY)
-                )
-            }
+            child.measure(
+                MeasureSpec.makeMeasureSpec(_childWidth, MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(childHeight, MeasureSpec.EXACTLY)
+            )
 
             params.updateMemoParams(
                 measuredWidth = _childWidth,

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/MediaPreviewHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/MediaPreviewHelper.kt
@@ -191,51 +191,52 @@ object MediaPreviewHelper {
             return
         }
 
-        var count = this.childCount
-        while (count > previewAbleList.size) {
-            if (this.childCount > 4) {
-                this.removeViewAt(this.childCount - 1)
-            } else {
-                this.getChildAt(count - 1).setMemoVisibility(View.GONE)
+        withSuspendLayout {
+            var count = this.childCount
+            while (count > previewAbleList.size) {
+                if (this.childCount > 4) {
+                    this.removeViewAt(this.childCount - 1)
+                } else {
+                    this.getChildAt(count - 1).setMemoVisibility(View.GONE)
+                }
+                count --
             }
-            count --
+
+            val inflater = LayoutInflater.from(this.context)
+            previewAbleList.forEachIndexed { index, previewAbleFile ->
+                val existsView: View? = this.getChildAt(index)
+                val binding = if (existsView == null) {
+                    ItemMediaPreviewBinding.inflate(inflater, this, false)
+                } else {
+                    ItemMediaPreviewBinding.bind(existsView)
+                }
+                binding.root.setMemoVisibility(View.VISIBLE)
+
+                binding.baseFrame.setClickWhenShowMediaActivityListener(
+                    binding.thumbnail,
+                    binding.actionButton,
+                    previewAbleFile,
+                    previewAbleList
+                )
+                binding.baseFrame.setOnClickListener {
+                    mediaViewData.show(index)
+                }
+
+                binding.thumbnail.setPreview(previewAbleFile, mediaViewData.config)
+
+                binding.actionButton.isVisible = previewAbleFile.isVisiblePlayButton
+                binding.nsfwMessage.isVisible = previewAbleFile.isHiding
+                binding.nsfwMessage.setHideImageMessage(previewAbleFile, mediaViewData.config)
+                binding.toggleVisibilityButton.setImageResource(if (previewAbleFile.isHiding) R.drawable.ic_baseline_image_24 else R.drawable.ic_baseline_hide_image_24)
+                binding.toggleVisibilityButton.setOnClickListener {
+                    mediaViewData.toggleVisibility(index)
+                }
+
+                if (existsView == null) {
+                    this.addView(binding.root)
+                }
+            }
         }
-
-        val inflater = LayoutInflater.from(this.context)
-        previewAbleList.forEachIndexed { index, previewAbleFile ->
-            val existsView: View? = this.getChildAt(index)
-            val binding = if (existsView == null) {
-                ItemMediaPreviewBinding.inflate(inflater, this, false)
-            } else {
-                ItemMediaPreviewBinding.bind(existsView)
-            }
-            binding.root.setMemoVisibility(View.VISIBLE)
-
-            binding.baseFrame.setClickWhenShowMediaActivityListener(
-                binding.thumbnail,
-                binding.actionButton,
-                previewAbleFile,
-                previewAbleList
-            )
-            binding.baseFrame.setOnClickListener {
-                mediaViewData.show(index)
-            }
-
-            binding.thumbnail.setPreview(previewAbleFile, mediaViewData.config)
-
-            binding.actionButton.isVisible = previewAbleFile.isVisiblePlayButton
-            binding.nsfwMessage.isVisible = previewAbleFile.isHiding
-            binding.nsfwMessage.setHideImageMessage(previewAbleFile, mediaViewData.config)
-            binding.toggleVisibilityButton.setImageResource(if (previewAbleFile.isHiding) R.drawable.ic_baseline_image_24 else R.drawable.ic_baseline_hide_image_24)
-            binding.toggleVisibilityButton.setOnClickListener {
-                mediaViewData.toggleVisibility(index)
-            }
-
-            if (existsView == null) {
-                this.addView(binding.root)
-            }
-        }
-
 
         this.visibility = View.VISIBLE
 


### PR DESCRIPTION
## やったこと
一部の計算結果の値をキャッシュするようにしました。
またwithSuspendLayoutという関数を作成し、
レイアウトの構築が完了するまで、onMeasureとonLayoutの処理をスキップできるようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



