### PR TITLE
ストリーミングを受信しないときは購読を解除するようにした

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/MiApplication.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/MiApplication.kt
@@ -15,8 +15,6 @@ import net.pantasystem.milktea.app_store.account.AccountStore
 import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.common_android.platform.activeNetworkFlow
 import net.pantasystem.milktea.data.infrastructure.MemoryCacheCleaner
-import net.pantasystem.milktea.data.infrastructure.streaming.ChannelAPIMainEventDispatcherAdapter
-import net.pantasystem.milktea.data.infrastructure.streaming.MediatorMainEventDispatcher
 import net.pantasystem.milktea.data.streaming.SocketWithAccountProvider
 import javax.inject.Inject
 
@@ -31,11 +29,8 @@ class MiApplication : Application(), Configuration.Provider {
     internal lateinit var mSocketWithAccountProvider: SocketWithAccountProvider
 
 
-    @Inject
-    internal lateinit var mainEventDispatcherFactory: MediatorMainEventDispatcher.Factory
 
-    @Inject
-    internal lateinit var channelAPIMainEventDispatcherAdapter: ChannelAPIMainEventDispatcherAdapter
+
 
     @Inject
     internal lateinit var applicationScope: CoroutineScope
@@ -73,9 +68,6 @@ class MiApplication : Application(), Configuration.Provider {
                 defaultUncaughtExceptionHandler?.uncaughtException(t, e)
             }
         }
-
-        val mainEventDispatcher = mainEventDispatcherFactory.create()
-        channelAPIMainEventDispatcherAdapter(mainEventDispatcher)
 
         applicationScope.launch {
             appStateController.initializeSettings()

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/MainActivityEventHandler.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/MainActivityEventHandler.kt
@@ -176,7 +176,7 @@ internal class MainActivityEventHandler(
 
         // NOTE: 最新の通知をSnackBar等に表示する
         lifecycleScope.launch {
-            lifecycleOwner.whenCreated {
+            lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 mainViewModel.newNotifications.collect { notificationRelation ->
                     activity.apply {
                         notificationMessageScope {

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/MainActivityEventHandler.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/MainActivityEventHandler.kt
@@ -30,23 +30,23 @@ import net.pantasystem.milktea.common_viewmodel.CurrentPageType
 import net.pantasystem.milktea.common_viewmodel.CurrentPageableTimelineViewModel
 import net.pantasystem.milktea.model.instance.FeatureEnables
 import net.pantasystem.milktea.model.note.draft.DraftNoteService
+import net.pantasystem.milktea.model.notification.Notification
 import net.pantasystem.milktea.model.user.report.ReportState
 import net.pantasystem.milktea.notification.notificationMessageScope
 import net.pantasystem.milktea.user.ReportStateHandler
 import net.pantasystem.milktea.worker.note.CreateNoteWorkerExecutor
 import javax.inject.Inject
 
-@Suppress("DEPRECATION")
 internal class MainActivityEventHandler(
     val activity: MainActivity,
     val binding: ActivityMainBinding,
-    val lifecycleScope: CoroutineScope,
-    val lifecycleOwner: LifecycleOwner,
-    val mainViewModel: MainViewModel,
+    private val lifecycleScope: CoroutineScope,
+    private val lifecycleOwner: LifecycleOwner,
+    private val mainViewModel: MainViewModel,
     val reportViewModel: ReportViewModel,
     private val createNoteWorkerExecutor: CreateNoteWorkerExecutor,
     val accountStore: AccountStore,
-    val requestPostNotificationsPermissionLauncher: ActivityResultLauncher<String>,
+    private val requestPostNotificationsPermissionLauncher: ActivityResultLauncher<String>,
     val changeNavMenuVisibilityFromAPIVersion: ChangeNavMenuVisibilityFromAPIVersion,
     private val configStore: SettingStore,
     private val draftNoteService: DraftNoteService,
@@ -188,16 +188,20 @@ internal class MainActivityEventHandler(
         }
         val audioManager = activity.getSystemService(Context.AUDIO_SERVICE) as AudioManager
 
+        var replayedNotifyId: Notification.Id?
         lifecycleScope.launch {
-            lifecycleOwner.whenResumed {
-                // NOTE: 通知音を再生する
+            lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 mainViewModel.newNotifications.collect {
+                    replayedNotifyId = it.notification.id
+                    if (replayedNotifyId == it.notification.id) {
+                        return@collect
+                    }
                     if (ringtone?.isPlaying == true) {
                         ringtone.stop()
                     }
                     if (
                         configStore.configState.value.isEnableNotificationSound
-                            && audioManager.ringerMode == AudioManager.RINGER_MODE_NORMAL
+                        && audioManager.ringerMode == AudioManager.RINGER_MODE_NORMAL
                     ) {
                         ringtone?.play()
                     }

--- a/modules/app_store/src/main/java/net/pantasystem/milktea/app_store/notes/TimelineStore.kt
+++ b/modules/app_store/src/main/java/net/pantasystem/milktea/app_store/notes/TimelineStore.kt
@@ -39,6 +39,8 @@ interface TimelineStore {
 
     suspend fun releaseUnusedPages(position: Int, offset: Int = 50)
 
+    fun setActiveStreamingChangedListener(listener: (Boolean) -> Unit)
+
 }
 
 sealed interface InitialLoadQuery {

--- a/modules/app_store/src/main/java/net/pantasystem/milktea/app_store/notes/TimelineStore.kt
+++ b/modules/app_store/src/main/java/net/pantasystem/milktea/app_store/notes/TimelineStore.kt
@@ -19,8 +19,8 @@ interface TimelineStore {
     val isActiveStreaming: Boolean
 
 
-    suspend fun loadPrevious(): Result<Unit>
-    suspend fun loadFuture(): Result<Unit>
+    suspend fun loadPrevious(): Result<Int>
+    suspend fun loadFuture(): Result<Int>
 
     /**
      * @param initialLoadQuery コンテンツが空の状態の時にloadPreviousを呼び出した時に

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/note/NoteStreamingImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/note/NoteStreamingImpl.kt
@@ -130,7 +130,7 @@ class NoteStreamingImpl @Inject constructor(
                 true
             }
         }.map {
-            noteDataSourceAdder.addNoteDtoToDataSource(account, it.body)
+            noteDataSourceAdder.addNoteDtoToDataSource(account, it.body, skipExists = true)
         }
     }
 
@@ -146,7 +146,7 @@ class NoteStreamingImpl @Inject constructor(
                 true
             }
         }.map {
-            noteDataSourceAdder.addTootStatusDtoIntoDataSource(account, it)
+            noteDataSourceAdder.addTootStatusDtoIntoDataSource(account, it, skipExists = true)
         }
     }
 

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/note/TimelineStoreImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/note/TimelineStoreImpl.kt
@@ -186,7 +186,7 @@ class TimelineStoreImpl(
     override suspend fun clear(initialLoadQuery: InitialLoadQuery?) {
         pageableStore.mutex.withLock {
             this.initialLoadQuery = initialLoadQuery
-            isActiveStreaming = true
+            isActiveStreaming = initialLoadQuery == null
             pageableStore.setState(PageableState.Loading.Init())
         }
     }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/note/TimelineStoreImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/note/TimelineStoreImpl.kt
@@ -206,6 +206,7 @@ class TimelineStoreImpl(
 
     override fun setActiveStreamingChangedListener(listener: (Boolean) -> Unit) {
         activeStreamingChangedListener = listener
+        listener(isActiveStreaming)
     }
 
     private suspend fun appendStreamEventNote(noteId: Note.Id) {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/note/TimelineStoreImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/note/TimelineStoreImpl.kt
@@ -129,8 +129,8 @@ class TimelineStoreImpl(
         }
     }
 
-    override suspend fun loadFuture(): Result<Unit> {
-        return runCancellableCatching<Unit> {
+    override suspend fun loadFuture(): Result<Int> {
+        return runCancellableCatching<Int> {
             val addedCount = when (val store = pageableStore) {
                 is TimelinePagingStoreImpl -> {
                     FuturePagingController.create(
@@ -153,12 +153,13 @@ class TimelineStoreImpl(
                 isActiveStreaming = true
             }
             latestReceiveId = null
+            addedCount.getOrThrow()
         }
     }
 
-    override suspend fun loadPrevious(): Result<Unit> {
-        return runCancellableCatching<Unit> {
-            when (val store = pageableStore) {
+    override suspend fun loadPrevious(): Result<Int> {
+        return runCancellableCatching<Int> {
+            val result = when (val store = pageableStore) {
                 is TimelinePagingStoreImpl -> {
                     PreviousPagingController.create(
                         store,
@@ -176,6 +177,7 @@ class TimelineStoreImpl(
                 }
             }
             latestReceiveId = null
+            result.getOrThrow()
         }
 
     }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/note/TimelineStoreImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/note/TimelineStoreImpl.kt
@@ -117,11 +117,8 @@ class TimelineStoreImpl(
 
     override var isActiveStreaming: Boolean = true
         private set(value) {
-            val oldValue = field
             field = value
-            if (oldValue != value) {
-                activeStreamingChangedListener?.invoke(value)
-            }
+            activeStreamingChangedListener?.invoke(value)
         }
 
     init {
@@ -206,7 +203,6 @@ class TimelineStoreImpl(
 
     override fun setActiveStreamingChangedListener(listener: (Boolean) -> Unit) {
         activeStreamingChangedListener = listener
-        listener(isActiveStreaming)
     }
 
     private suspend fun appendStreamEventNote(noteId: Note.Id) {

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
@@ -241,6 +241,8 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
                 super.onItemRangeInserted(positionStart, itemCount)
                 if (mViewModel.timelineStore.latestReceiveNoteId() != null && positionStart == 0 && mFirstVisibleItemPosition == 0 && isShowing && itemCount == 1) {
                     lm.scrollToPosition(0)
+                } else {
+                    mViewModel.onScrollPositionChanged(lm.findFirstVisibleItemPosition())
                 }
             }
         })

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/NoteStreamingCollector.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/NoteStreamingCollector.kt
@@ -30,15 +30,19 @@ internal class NoteStreamingCollector(
 
     private var job: Job? = null
 
-    fun onSuspend() {
+    fun suspendStreaming() {
         synchronized(this) {
             job?.cancel()
             job = null
         }
     }
 
+    fun resumeStreaming() {
+        startObserveStreaming()
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
-    fun onResume() {
+    private fun startObserveStreaming() {
         synchronized(this) {
             if (job != null) {
                 return
@@ -52,6 +56,5 @@ internal class NoteStreamingCollector(
                     logger.error("receive not error", it)
                 }.launchIn(coroutineScope + Dispatchers.IO)
         }
-
     }
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -291,10 +291,6 @@ class TimelineViewModel @AssistedInject constructor(
         if (config?.isEnableStreamingAPIAndNoteCapture == false) {
             // NOTE: 自動更新が無効なのでStreaming APIを停止している
             timelineStore.suspendStreaming()
-            noteStreamingCollector.suspendStreaming()
-        } else {
-            // NOTE: 自動更新が有効なのでStreaming APIを再開している
-            noteStreamingCollector.resumeStreaming()
         }
     }
 
@@ -319,7 +315,6 @@ class TimelineViewModel @AssistedInject constructor(
 
         if (config?.isStopStreamingApiWhenBackground == true) {
             timelineStore.suspendStreaming()
-            noteStreamingCollector.suspendStreaming()
         }
     }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -122,7 +122,7 @@ class TimelineViewModel @AssistedInject constructor(
 
     private val pagingCoroutineScope = PagingLoaderScopeController(viewModelScope)
 
-    private var isActive = true
+    private var isActive = false
 
     private val saveScrollPositionScrolledEvent = MutableSharedFlow<Int>(extraBufferCapacity = 4)
 
@@ -157,8 +157,8 @@ class TimelineViewModel @AssistedInject constructor(
         })
         cache.addFilter(ExcludeRepostOrReplyFilter(pageable))
 
-        timelineStore.setActiveStreamingChangedListener { isActive ->
-            if (isActive) {
+        timelineStore.setActiveStreamingChangedListener { isActiveStreaming ->
+            if (isActiveStreaming && isActive) {
                 val config = configRepository.get().getOrNull()
                 if (config?.isEnableStreamingAPIAndNoteCapture == true) {
                     noteStreamingCollector.resumeStreaming()

--- a/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationFragment.kt
+++ b/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationFragment.kt
@@ -184,6 +184,13 @@ class NotificationFragment : Fragment(R.layout.fragment_notification) {
         super.onResume()
 
         currentPageableTimelineViewModel.setCurrentPageable(null, Pageable.Notification())
+        mViewModel.onResume()
+    }
+
+    override fun onPause() {
+        super.onPause()
+
+        mViewModel.onPause()
     }
 
     private val mScrollListener = object : RecyclerView.OnScrollListener() {


### PR DESCRIPTION
## やったこと
現状タイムラインの購読位置に応じてストリーミングの受信をキャンセルしていたが、
実態のWebSocketのストリーミング状態の購読の解除を行なっていなかったため、
無駄にリソースを消費してしまっていた。
これを改善するために、ストリーミングの受診をキャンセルしているときは、
ストリーミングの購読を解除するようにした。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



