### PR TITLE
feat: フォローボタンのデザインをわかりやすくする

### DIFF
--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/FollowButton.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/FollowButton.kt
@@ -1,0 +1,51 @@
+package net.pantasystem.milktea.user
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import net.pantasystem.milktea.model.user.FollowState
+
+@Composable
+fun FollowButton(
+    userState: FollowState?,
+    isMine: Boolean,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    val buttonText = getFollowStateString(userState)
+    if (!isMine) {
+        when (userState) {
+            FollowState.UNFOLLOWING, FollowState.UNFOLLOWING_LOCKED -> {
+                OutlinedButton(
+                    shape = RoundedCornerShape(32.dp),
+                    onClick = onClick,
+                ) {
+                    Text(buttonText)
+                }
+            }
+            FollowState.FOLLOWING, FollowState.PENDING_FOLLOW_REQUEST -> {
+                Button(
+                    shape = RoundedCornerShape(32.dp),
+                    onClick = onClick,
+                ) {
+                    Text(buttonText)
+                }
+            }
+            null -> {  }
+        }
+    }
+}
+
+@Composable
+private fun getFollowStateString(state: FollowState?): String = when (state) {
+    FollowState.FOLLOWING -> stringResource(R.string.unfollow)
+    FollowState.UNFOLLOWING -> stringResource(R.string.follow)
+    FollowState.UNFOLLOWING_LOCKED -> stringResource(R.string.request_follow_from_u)
+    FollowState.PENDING_FOLLOW_REQUEST -> stringResource(R.string.follow_approval_pending)
+    else -> ""
+}

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/UserDetailActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/UserDetailActivity.kt
@@ -15,8 +15,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.app.TaskStackBuilder
 import androidx.databinding.DataBindingUtil
@@ -193,33 +197,47 @@ class UserDetailActivity : AppCompatActivity() {
             }
         }
 
+        @Composable
+        fun FollowButton(
+            userDetail: User.Detail?,
+            isMine: State<Boolean>,
+            buttonText: String,
+            modifier: Modifier = Modifier,
+        ) {
+            if (!isMine.value) {
+                when (userDetail?.followState) {
+                    FollowState.UNFOLLOWING, FollowState.UNFOLLOWING_LOCKED -> {
+                        OutlinedButton(
+                            shape = RoundedCornerShape(32.dp),
+                            onClick = { mViewModel.changeFollow() },
+                        ) {
+                            Text(buttonText)
+                        }
+                    }
+                    FollowState.FOLLOWING, FollowState.PENDING_FOLLOW_REQUEST -> {
+                        Button(
+                            shape = RoundedCornerShape(32.dp),
+                            onClick = { mViewModel.changeFollow() },
+                        ) {
+                            Text(buttonText)
+                        }
+                    }
+                    else -> {  }
+                }
+            }
+        }
+
         binding.followButton.apply {
             setContent {
                 val userDetail by mViewModel.userState.collectAsState()
                 val isMine = mViewModel.isMine.collectAsState()
                 val buttonText = setFollowState(userDetail?.followState)
                 MdcTheme {
-                    if (!isMine.value) {
-                        when (userDetail?.followState) {
-                            FollowState.UNFOLLOWING, FollowState.UNFOLLOWING_LOCKED -> {
-                                OutlinedButton(
-                                    shape = RoundedCornerShape(32.dp),
-                                    onClick = { mViewModel.changeFollow() },
-                                ) {
-                                    Text(buttonText)
-                                }
-                            }
-                            FollowState.FOLLOWING, FollowState.PENDING_FOLLOW_REQUEST -> {
-                                Button(
-                                    shape = RoundedCornerShape(32.dp),
-                                    onClick = { mViewModel.changeFollow() },
-                                ) {
-                                    Text(buttonText)
-                                }
-                            }
-                            else -> {  }
-                        }
-                    }
+                    FollowButton(
+                        userDetail = userDetail,
+                        isMine = isMine,
+                        buttonText = buttonText,
+                    )
                 }
             }
         }
@@ -509,11 +527,12 @@ class UserDetailActivity : AppCompatActivity() {
         binding.remoteUserState.setBackgroundColor(typed.data)
     }
 
+    @Composable
     private fun setFollowState(state: FollowState?): String = when (state) {
-        FollowState.FOLLOWING -> getString(R.string.unfollow)
-        FollowState.UNFOLLOWING -> getString(R.string.follow)
-        FollowState.UNFOLLOWING_LOCKED -> getString(R.string.request_follow_from_u)
-        FollowState.PENDING_FOLLOW_REQUEST -> getString(R.string.follow_approval_pending)
+        FollowState.FOLLOWING -> stringResource(R.string.unfollow)
+        FollowState.UNFOLLOWING -> stringResource(R.string.follow)
+        FollowState.UNFOLLOWING_LOCKED -> stringResource(R.string.request_follow_from_u)
+        FollowState.PENDING_FOLLOW_REQUEST -> stringResource(R.string.follow_approval_pending)
         else -> ""
     }
 

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/UserDetailActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/UserDetailActivity.kt
@@ -11,8 +11,13 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Text
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.unit.dp
 import androidx.core.app.TaskStackBuilder
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.*
@@ -39,6 +44,7 @@ import net.pantasystem.milktea.common_navigation.*
 import net.pantasystem.milktea.model.setting.Config
 import net.pantasystem.milktea.model.setting.LocalConfigRepository
 import net.pantasystem.milktea.model.setting.Theme
+import net.pantasystem.milktea.model.user.FollowState
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.note.NoteEditorActivity
 import net.pantasystem.milktea.note.view.NoteActionHandler
@@ -183,6 +189,37 @@ class UserDetailActivity : AppCompatActivity() {
                             )
                         }
                     )
+                }
+            }
+        }
+
+        binding.followButton.apply {
+            setContent {
+                val userDetail by mViewModel.userState.collectAsState()
+                val isMine = mViewModel.isMine.collectAsState()
+                val buttonText = setFollowState(userDetail?.followState)
+                MdcTheme {
+                    if (!isMine.value) {
+                        when (userDetail?.followState) {
+                            FollowState.UNFOLLOWING, FollowState.UNFOLLOWING_LOCKED -> {
+                                OutlinedButton(
+                                    shape = RoundedCornerShape(32.dp),
+                                    onClick = { mViewModel.changeFollow() },
+                                ) {
+                                    Text(buttonText)
+                                }
+                            }
+                            FollowState.FOLLOWING, FollowState.PENDING_FOLLOW_REQUEST -> {
+                                Button(
+                                    shape = RoundedCornerShape(32.dp),
+                                    onClick = { mViewModel.changeFollow() },
+                                ) {
+                                    Text(buttonText)
+                                }
+                            }
+                            else -> {  }
+                        }
+                    }
                 }
             }
         }
@@ -472,6 +509,13 @@ class UserDetailActivity : AppCompatActivity() {
         binding.remoteUserState.setBackgroundColor(typed.data)
     }
 
+    private fun setFollowState(state: FollowState?): String = when (state) {
+        FollowState.FOLLOWING -> getString(R.string.unfollow)
+        FollowState.UNFOLLOWING -> getString(R.string.follow)
+        FollowState.UNFOLLOWING_LOCKED -> getString(R.string.request_follow_from_u)
+        FollowState.PENDING_FOLLOW_REQUEST -> getString(R.string.follow_approval_pending)
+        else -> ""
+    }
 
     @ExperimentalCoroutinesApi
     private fun addPageToTab() {

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/UserDetailActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/UserDetailActivity.kt
@@ -11,16 +11,8 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Button
-import androidx.compose.material.OutlinedButton
-import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.core.app.TaskStackBuilder
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.*
@@ -47,11 +39,11 @@ import net.pantasystem.milktea.common_navigation.*
 import net.pantasystem.milktea.model.setting.Config
 import net.pantasystem.milktea.model.setting.LocalConfigRepository
 import net.pantasystem.milktea.model.setting.Theme
-import net.pantasystem.milktea.model.user.FollowState
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.note.NoteEditorActivity
 import net.pantasystem.milktea.note.view.NoteActionHandler
 import net.pantasystem.milktea.note.viewmodel.NotesViewModel
+import net.pantasystem.milktea.user.FollowButton
 import net.pantasystem.milktea.user.R
 import net.pantasystem.milktea.user.databinding.ActivityUserDetailBinding
 import net.pantasystem.milktea.user.followlist.FollowFollowerActivity
@@ -493,46 +485,6 @@ class UserDetailActivity : AppCompatActivity() {
             theme.resolveAttribute(R.attr.background, typed, true)
         }
         binding.remoteUserState.setBackgroundColor(typed.data)
-    }
-
-    @Composable
-    fun FollowButton(
-        userState: FollowState?,
-        isMine: Boolean,
-        modifier: Modifier = Modifier,
-        onClick: () -> Unit,
-    ) {
-        val buttonText = setFollowState(userState)
-        if (!isMine) {
-            when (userState) {
-                FollowState.UNFOLLOWING, FollowState.UNFOLLOWING_LOCKED -> {
-                    OutlinedButton(
-                        shape = RoundedCornerShape(32.dp),
-                        onClick = onClick,
-                    ) {
-                        Text(buttonText)
-                    }
-                }
-                FollowState.FOLLOWING, FollowState.PENDING_FOLLOW_REQUEST -> {
-                    Button(
-                        shape = RoundedCornerShape(32.dp),
-                        onClick = onClick,
-                    ) {
-                        Text(buttonText)
-                    }
-                }
-                null -> {  }
-            }
-        }
-    }
-
-    @Composable
-    private fun setFollowState(state: FollowState?): String = when (state) {
-        FollowState.FOLLOWING -> stringResource(R.string.unfollow)
-        FollowState.UNFOLLOWING -> stringResource(R.string.follow)
-        FollowState.UNFOLLOWING_LOCKED -> stringResource(R.string.request_follow_from_u)
-        FollowState.PENDING_FOLLOW_REQUEST -> stringResource(R.string.follow_approval_pending)
-        else -> ""
     }
 
     @ExperimentalCoroutinesApi

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/UserDetailActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/UserDetailActivity.kt
@@ -197,36 +197,6 @@ class UserDetailActivity : AppCompatActivity() {
             }
         }
 
-        @Composable
-        fun FollowButton(
-            userDetail: User.Detail?,
-            isMine: State<Boolean>,
-            buttonText: String,
-            modifier: Modifier = Modifier,
-        ) {
-            if (!isMine.value) {
-                when (userDetail?.followState) {
-                    FollowState.UNFOLLOWING, FollowState.UNFOLLOWING_LOCKED -> {
-                        OutlinedButton(
-                            shape = RoundedCornerShape(32.dp),
-                            onClick = { mViewModel.changeFollow() },
-                        ) {
-                            Text(buttonText)
-                        }
-                    }
-                    FollowState.FOLLOWING, FollowState.PENDING_FOLLOW_REQUEST -> {
-                        Button(
-                            shape = RoundedCornerShape(32.dp),
-                            onClick = { mViewModel.changeFollow() },
-                        ) {
-                            Text(buttonText)
-                        }
-                    }
-                    else -> {  }
-                }
-            }
-        }
-
         binding.followButton.apply {
             setContent {
                 val userDetail by mViewModel.userState.collectAsState()
@@ -525,6 +495,36 @@ class UserDetailActivity : AppCompatActivity() {
             theme.resolveAttribute(R.attr.background, typed, true)
         }
         binding.remoteUserState.setBackgroundColor(typed.data)
+    }
+
+    @Composable
+    fun FollowButton(
+        userDetail: User.Detail?,
+        isMine: State<Boolean>,
+        buttonText: String,
+        modifier: Modifier = Modifier,
+    ) {
+        if (!isMine.value) {
+            when (userDetail?.followState) {
+                FollowState.UNFOLLOWING, FollowState.UNFOLLOWING_LOCKED -> {
+                    OutlinedButton(
+                        shape = RoundedCornerShape(32.dp),
+                        onClick = { mViewModel.changeFollow() },
+                    ) {
+                        Text(buttonText)
+                    }
+                }
+                FollowState.FOLLOWING, FollowState.PENDING_FOLLOW_REQUEST -> {
+                    Button(
+                        shape = RoundedCornerShape(32.dp),
+                        onClick = { mViewModel.changeFollow() },
+                    ) {
+                        Text(buttonText)
+                    }
+                }
+                else -> {  }
+            }
+        }
     }
 
     @Composable

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/UserDetailActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/UserDetailActivity.kt
@@ -16,7 +16,6 @@ import androidx.compose.material.Button
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -200,13 +199,12 @@ class UserDetailActivity : AppCompatActivity() {
         binding.followButton.apply {
             setContent {
                 val userDetail by mViewModel.userState.collectAsState()
-                val isMine = mViewModel.isMine.collectAsState()
-                val buttonText = setFollowState(userDetail?.followState)
+                val isMine by mViewModel.isMine.collectAsState()
                 MdcTheme {
                     FollowButton(
-                        userDetail = userDetail,
+                        userState = userDetail?.followState,
                         isMine = isMine,
-                        buttonText = buttonText,
+                        onClick = { mViewModel.changeFollow() }
                     )
                 }
             }
@@ -499,17 +497,18 @@ class UserDetailActivity : AppCompatActivity() {
 
     @Composable
     fun FollowButton(
-        userDetail: User.Detail?,
-        isMine: State<Boolean>,
-        buttonText: String,
+        userState: FollowState?,
+        isMine: Boolean,
         modifier: Modifier = Modifier,
+        onClick: () -> Unit,
     ) {
-        if (!isMine.value) {
-            when (userDetail?.followState) {
+        val buttonText = setFollowState(userState)
+        if (!isMine) {
+            when (userState) {
                 FollowState.UNFOLLOWING, FollowState.UNFOLLOWING_LOCKED -> {
                     OutlinedButton(
                         shape = RoundedCornerShape(32.dp),
-                        onClick = { mViewModel.changeFollow() },
+                        onClick = onClick,
                     ) {
                         Text(buttonText)
                     }
@@ -517,12 +516,12 @@ class UserDetailActivity : AppCompatActivity() {
                 FollowState.FOLLOWING, FollowState.PENDING_FOLLOW_REQUEST -> {
                     Button(
                         shape = RoundedCornerShape(32.dp),
-                        onClick = { mViewModel.changeFollow() },
+                        onClick = onClick,
                     ) {
                         Text(buttonText)
                     }
                 }
-                else -> {  }
+                null -> {  }
             }
         }
     }

--- a/modules/features/user/src/main/res/layout/activity_user_detail.xml
+++ b/modules/features/user/src/main/res/layout/activity_user_detail.xml
@@ -120,19 +120,12 @@
                             app:layout_constraintTop_toTopOf="@id/avatarIcon"
                             app:layout_constraintBottom_toBottomOf="@id/avatarIcon"
                             >
-
-
-                        <com.google.android.material.button.MaterialButton
-                                android:id="@+id/followButton"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="bottom"
-                                tools:text="フォロー"
-                                followState="@{userViewModel.userState.followState}"
-                                android:visibility="@{userViewModel.mine ? View.GONE : View.VISIBLE}"
-                                android:onClick="@{()-> userViewModel.changeFollow()}"
-                                app:cornerRadius="32dp"
-                                />
+                        <androidx.compose.ui.platform.ComposeView
+                            android:id="@+id/followButton"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="bottom"
+                            />
                     </LinearLayout>
 
                     <TextView


### PR DESCRIPTION
# 概要
以前までは、プロフィール画面、ユーザ一覧画面のフォローボタンのデザインがフォロー・非フォロー状態に関わらず同じような見た目で分かりづらかった。 

# 変更点
- プロフィール画面のフォローボタンのデザインを、ユーザー一覧画面のようにフォロー・非フォロー状態次第で見た目を切り替える

## スクリーンショット(任意)
フォロー中 | 非フォロー |  非フォロー申請済み | 非フォロー未申請 |
:--: | :--:| :--:| :--:
![image](https://github.com/pantasystem/Milktea/assets/62137820/15950ce3-01cb-4758-81a3-dcc5fc56fa62)|![image](https://github.com/pantasystem/Milktea/assets/62137820/8875ce9f-ecd0-4665-a8c4-faa01a0268e9)|![image](https://github.com/pantasystem/Milktea/assets/62137820/7c10743d-e544-4b20-817a-9d9bc9a6f88a)|![image](https://github.com/pantasystem/Milktea/assets/62137820/ea36022d-dd28-4d62-939a-612f9ceaa025)|


## Issue番号
Fixes #1955


