### PR TITLE
常にメディアを表示するオプションを追加した

### DIFF
--- a/app/src/test/java/net/pantasystem/milktea/note/media/viewmodel/MediaViewDataTest.kt
+++ b/app/src/test/java/net/pantasystem/milktea/note/media/viewmodel/MediaViewDataTest.kt
@@ -1,0 +1,172 @@
+package net.pantasystem.milktea.note.media.viewmodel
+
+import net.pantasystem.milktea.model.drive.FileProperty
+import net.pantasystem.milktea.model.drive.make
+import net.pantasystem.milktea.model.file.AppFile
+import net.pantasystem.milktea.model.file.FilePreviewSource
+import net.pantasystem.milktea.model.setting.DefaultConfig
+import net.pantasystem.milktea.model.setting.MediaDisplayMode
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class MediaViewDataTest {
+
+    @Test
+    fun initialFiles_GiveAlwaysShow() {
+
+        val config = DefaultConfig.config.copy(
+            mediaDisplayMode = MediaDisplayMode.ALWAYS_SHOW
+        )
+        val files = listOf(
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1")),
+            ),
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1")),
+            ),
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1"), isSensitive = true),
+            ),
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1")),
+            )
+        )
+        val value = MediaViewData(files, config).files.value
+        Assertions.assertEquals(
+            listOf(
+                PreviewAbleFile.VisibleType.Visible,
+                PreviewAbleFile.VisibleType.Visible,
+                PreviewAbleFile.VisibleType.Visible,
+                PreviewAbleFile.VisibleType.Visible
+            ),
+            value.map {
+                it.initialVisibleType
+            }
+        )
+    }
+
+    /**
+     * configのmediaDisplayModeがMediaDisplayMode.ALWAYS_HIDEの場合のテストコード
+     */
+    @Test
+    fun initialFiles_GiveAlwaysHide() {
+
+        val config = DefaultConfig.config.copy(
+            mediaDisplayMode = MediaDisplayMode.ALWAYS_HIDE
+        )
+        val files = listOf(
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1")),
+            ),
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1")),
+            ),
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1"), isSensitive = true),
+            ),
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1")),
+            )
+        )
+        val value = MediaViewData(files, config).files.value
+        Assertions.assertEquals(
+            listOf(
+                PreviewAbleFile.VisibleType.HideWhenMobileNetwork,
+                PreviewAbleFile.VisibleType.HideWhenMobileNetwork,
+                PreviewAbleFile.VisibleType.SensitiveHide,
+                PreviewAbleFile.VisibleType.HideWhenMobileNetwork
+            ),
+            value.map {
+                it.initialVisibleType
+            }
+        )
+    }
+
+    /**
+     * configのmediaDisplayModeがMediaDisplayMode.ALWAYS_HIDE_WHEN_MOBILE_NETWORKの場合のテストコード
+     */
+    @Test
+    fun initialFiles_GiveAlwaysHideWhenMobileNetwork() {
+
+        val config = DefaultConfig.config.copy(
+            mediaDisplayMode = MediaDisplayMode.ALWAYS_HIDE_WHEN_MOBILE_NETWORK
+        )
+        val files = listOf(
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1")),
+            ),
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1")),
+            ),
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1"), isSensitive = true),
+            ),
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1")),
+            )
+        )
+        val value = MediaViewData(files, config).files.value
+        Assertions.assertEquals(
+            listOf(
+                PreviewAbleFile.VisibleType.HideWhenMobileNetwork,
+                PreviewAbleFile.VisibleType.HideWhenMobileNetwork,
+                PreviewAbleFile.VisibleType.SensitiveHide,
+                PreviewAbleFile.VisibleType.HideWhenMobileNetwork
+            ),
+            value.map {
+                it.initialVisibleType
+            }
+        )
+    }
+
+    /**
+     * configのmediaDisplayModeがMediaDisplayMode.AUTOの場合のテストコード
+     */
+    @Test
+    fun initialFiles_GiveAuto() {
+
+        val config = DefaultConfig.config.copy(
+            mediaDisplayMode = MediaDisplayMode.AUTO
+        )
+        val files = listOf(
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1")),
+            ),
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1")),
+            ),
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1"), isSensitive = true),
+            ),
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1")),
+            )
+        )
+        val value = MediaViewData(files, config).files.value
+        Assertions.assertEquals(
+            listOf(
+                PreviewAbleFile.VisibleType.Visible,
+                PreviewAbleFile.VisibleType.Visible,
+                PreviewAbleFile.VisibleType.SensitiveHide,
+                PreviewAbleFile.VisibleType.Visible
+            ),
+            value.map { it.initialVisibleType }
+        )
+    }
+}

--- a/app/src/test/java/net/pantasystem/milktea/note/media/viewmodel/MediaViewDataTest.kt
+++ b/app/src/test/java/net/pantasystem/milktea/note/media/viewmodel/MediaViewDataTest.kt
@@ -1,5 +1,6 @@
 package net.pantasystem.milktea.note.media.viewmodel
 
+import kotlinx.coroutines.test.runTest
 import net.pantasystem.milktea.model.drive.FileProperty
 import net.pantasystem.milktea.model.drive.make
 import net.pantasystem.milktea.model.file.AppFile
@@ -169,4 +170,140 @@ class MediaViewDataTest {
             value.map { it.initialVisibleType }
         )
     }
+
+    /**
+     * toggleVisibilityのテストコード
+     */
+    @Test
+    fun toggleVisibility_GiveConfigAsAuto() = runTest {
+        val config = DefaultConfig.config.copy(
+            mediaDisplayMode = MediaDisplayMode.AUTO
+        )
+        val files = listOf(
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1")),
+            ),
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1")),
+            ),
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1"), isSensitive = true),
+            ),
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(id = FileProperty.Id(0L, "1")),
+            )
+        )
+        val mediaViewData = MediaViewData(files, config)
+        mediaViewData.toggleVisibility(0)
+        Assertions.assertEquals(
+            listOf(
+                PreviewAbleFile.VisibleType.SensitiveHide,
+                PreviewAbleFile.VisibleType.Visible,
+                PreviewAbleFile.VisibleType.SensitiveHide,
+                PreviewAbleFile.VisibleType.Visible
+            ),
+            mediaViewData.files.value.map { it.visibleType }
+        )
+
+        mediaViewData.toggleVisibility(2)
+        Assertions.assertEquals(
+            listOf(
+                PreviewAbleFile.VisibleType.SensitiveHide,
+                PreviewAbleFile.VisibleType.Visible,
+                PreviewAbleFile.VisibleType.Visible,
+                PreviewAbleFile.VisibleType.Visible
+            ),
+            mediaViewData.files.value.map { it.visibleType }
+        )
+
+        mediaViewData.toggleVisibility(2)
+        Assertions.assertEquals(
+            listOf(
+                PreviewAbleFile.VisibleType.SensitiveHide,
+                PreviewAbleFile.VisibleType.Visible,
+                PreviewAbleFile.VisibleType.SensitiveHide,
+                PreviewAbleFile.VisibleType.Visible
+            ),
+            mediaViewData.files.value.map { it.visibleType }
+        )
+
+    }
+
+    /**
+     * toggleVisibilityのテストコード、modeがALWAYS_HIDE_WHEN_MOBILE_NETWORKの時
+     */
+    @Test
+    fun toggleVisibility_GiveConfigAsAlwaysHideWhenMobileNetwork() = runTest {
+        val config = DefaultConfig.config.copy(
+            mediaDisplayMode = MediaDisplayMode.ALWAYS_HIDE_WHEN_MOBILE_NETWORK
+        )
+        val files = listOf(
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(
+                    id = FileProperty.Id(0L, "1"),
+                    isSensitive = true
+                ),
+            ),
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(
+                    id = FileProperty.Id(0L, "1"),
+                    isSensitive = false
+                ),
+            ),
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(
+                    id = FileProperty.Id(0L, "1"),
+                    isSensitive = false
+                ),
+            ),
+            FilePreviewSource.Remote(
+                AppFile.Remote(id = FileProperty.Id(0L, "1")),
+                FileProperty.make(
+                    id = FileProperty.Id(0L, "1"),
+                    isSensitive = false
+                ),
+            )
+        )
+        val mediaViewData = MediaViewData(files, config)
+        mediaViewData.toggleVisibility(0)
+        Assertions.assertEquals(
+            listOf(
+                PreviewAbleFile.VisibleType.Visible,
+                PreviewAbleFile.VisibleType.HideWhenMobileNetwork,
+                PreviewAbleFile.VisibleType.HideWhenMobileNetwork,
+                PreviewAbleFile.VisibleType.HideWhenMobileNetwork
+            ),
+            mediaViewData.files.value.map { it.visibleType }
+        )
+
+        mediaViewData.toggleVisibility(1)
+        Assertions.assertEquals(
+            listOf(
+                PreviewAbleFile.VisibleType.Visible,
+                PreviewAbleFile.VisibleType.Visible,
+                PreviewAbleFile.VisibleType.HideWhenMobileNetwork,
+                PreviewAbleFile.VisibleType.HideWhenMobileNetwork
+            ),
+            mediaViewData.files.value.map { it.visibleType }
+        )
+        mediaViewData.toggleVisibility(1)
+        Assertions.assertEquals(
+            listOf(
+                PreviewAbleFile.VisibleType.Visible,
+                PreviewAbleFile.VisibleType.SensitiveHide,
+                PreviewAbleFile.VisibleType.HideWhenMobileNetwork,
+                PreviewAbleFile.VisibleType.HideWhenMobileNetwork
+            ),
+            mediaViewData.files.value.map { it.visibleType }
+        )
+
+    }
+
 }

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -453,6 +453,7 @@
     <string name="note_editor_poll_choice_n">候補%d</string>
     <string name="settings_visible_instance_domain_in_toolbar">ツールバーにサーバのドメインを表示する</string>
     <string name="settings_hide_media_when_mobile_network">モバイル ネットワーク時にメディアを非表示にする</string>
+    <string name="settings_always_show_media">常にメディアを表示する</string>
     <string name="notes_media_click_to_load_image">クリックして画像を読み込み</string>
     <string name="notifications_follow_requests">フォローリクエスト</string>
     <string name="content_not_exists_message">何もありません</string>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -449,6 +449,7 @@
     <string name="note_editor_poll_choice_n">选择%d</string>
     <string name="settings_visible_instance_domain_in_toolbar">在工具栏中显示实例的域</string>
     <string name="settings_hide_media_when_mobile_network">移动网络时隐藏媒体</string>
+    <string name="settings_always_show_media">始终显示媒体</string>
     <string name="notes_media_click_to_load_image">点击加载图片</string>
     <string name="notifications_follow_requests">按照要求</string>
     <string name="content_not_exists_message">无内容</string>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -443,6 +443,7 @@
     <string name="note_editor_poll_choice_n">Choice %d</string>
     <string name="settings_visible_instance_domain_in_toolbar">Show the instance\'s domain in the toolbar</string>
     <string name="settings_hide_media_when_mobile_network">Hide media when mobile network</string>
+    <string name="settings_always_show_media">Always show media</string>
     <string name="notes_media_click_to_load_image">Click to load Image</string>
     <string name="notifications_follow_requests">Follow request</string>
     <string name="content_not_exists_message">No content</string>

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/viewmodel/MediaViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/viewmodel/MediaViewData.kt
@@ -1,11 +1,7 @@
 package net.pantasystem.milktea.note.media.viewmodel
 
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import net.pantasystem.milktea.model.file.FilePreviewSource
 import net.pantasystem.milktea.model.file.isSensitive
@@ -16,44 +12,35 @@ import net.pantasystem.milktea.model.setting.MediaDisplayMode
 class MediaViewData(
     files: List<FilePreviewSource>,
     val config: Config?,
-    coroutineScope: CoroutineScope,
 ) {
 
     // NOTE: サイズが変わることは決してない
-    private val _files = MutableStateFlow(files.map {
-        PreviewAbleFile(
-            it,
-            if (it.isSensitive)
-                PreviewAbleFile.VisibleType.SensitiveHide
-            else if (when(config?.mediaDisplayMode ?: DefaultConfig.config.mediaDisplayMode) {
-                    MediaDisplayMode.AUTO -> false
-                    MediaDisplayMode.ALWAYS_HIDE -> true
-                    MediaDisplayMode.ALWAYS_HIDE_WHEN_MOBILE_NETWORK -> true
-                })
-                PreviewAbleFile.VisibleType.HideWhenMobileNetwork
-            else
-                PreviewAbleFile.VisibleType.Visible
-        )
-    })
+    private val _files = MutableStateFlow(
+        files.map {
+            PreviewAbleFile(
+                it,
+                if (it.isSensitive) {
+                    if (config?.mediaDisplayMode == MediaDisplayMode.ALWAYS_SHOW) {
+                        PreviewAbleFile.VisibleType.Visible
+                    } else {
+                        PreviewAbleFile.VisibleType.SensitiveHide
+                    }
+                } else if (when (config?.mediaDisplayMode
+                        ?: DefaultConfig.config.mediaDisplayMode) {
+                        MediaDisplayMode.AUTO -> false
+                        MediaDisplayMode.ALWAYS_HIDE -> true
+                        MediaDisplayMode.ALWAYS_HIDE_WHEN_MOBILE_NETWORK -> true
+                        MediaDisplayMode.ALWAYS_SHOW -> false
+                    }
+                ) {
+                    PreviewAbleFile.VisibleType.HideWhenMobileNetwork
+                } else {
+                    PreviewAbleFile.VisibleType.Visible
+                }
+            )
+        },
+    )
     val files: StateFlow<List<PreviewAbleFile>> = _files
-
-    val isHideFourMediaPreviewLayout = _files.map { it.isEmpty() || it.size > 4 }.stateIn(coroutineScope, SharingStarted.WhileSubscribed(5_000), true)
-
-    val fileOne = _files.map {
-        it.getOrNull(0)
-    }.stateIn(coroutineScope, SharingStarted.WhileSubscribed(5_000), null)
-
-    val fileTwo = _files.map {
-        it.getOrNull(1)
-    }.stateIn(coroutineScope, SharingStarted.WhileSubscribed(5_000), null)
-
-    val fileThree = _files.map {
-        it.getOrNull(2)
-    }.stateIn(coroutineScope, SharingStarted.WhileSubscribed(5_000), null)
-
-    val fileFour = _files.map {
-        it.getOrNull(3)
-    }.stateIn(coroutineScope, SharingStarted.WhileSubscribed(5_000), null)
 
     val isOver4Files = files.size > 4
     val isVisibleMediaPreviewArea = !(isOver4Files || files.isEmpty())

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -106,7 +106,7 @@ open class PlaneNoteViewData(
     }?.filter {
         it.aboutMediaType == AboutMediaType.IMAGE || it.aboutMediaType == AboutMediaType.VIDEO
     } ?: emptyList()
-    val media = MediaViewData(previewableFiles, configRepository.get().getOrNull(), coroutineScope)
+    val media = MediaViewData(previewableFiles, configRepository.get().getOrNull())
 
     val isOnlyVisibleRenoteStatusMessage = MutableStateFlow<Boolean>(false)
 
@@ -195,7 +195,7 @@ open class PlaneNoteViewData(
     val subNoteFiles = subNote?.files ?: emptyList()
     val subNoteMedia = MediaViewData(subNote?.files?.map {
         FilePreviewSource.Remote(AppFile.Remote(it.id), it)
-    } ?: emptyList(), configRepository.get().getOrNull(), coroutineScope)
+    } ?: emptyList(), configRepository.get().getOrNull())
 
     val channelInfo = (toShowNote.note.type as? Note.Type.Misskey)?.channel
 

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingMovementActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingMovementActivity.kt
@@ -209,7 +209,9 @@ class SettingMovementActivity : AppCompatActivity() {
                             }
                         }
                         SettingSection(title = stringResource(id = R.string.media)) {
-                            Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
+                            Box(modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp)) {
                                 var isVisibleDropdown by remember {
                                     mutableStateOf(false)
                                 }
@@ -273,5 +275,6 @@ private fun stringFromDisplayMode(displayMode: MediaDisplayMode): String {
         MediaDisplayMode.AUTO -> stringResource(R.string.media_display_mode_default)
         MediaDisplayMode.ALWAYS_HIDE -> stringResource(id = R.string.media_display_mode_always)
         MediaDisplayMode.ALWAYS_HIDE_WHEN_MOBILE_NETWORK -> stringResource(id = R.string.settings_hide_media_when_mobile_network)
+        MediaDisplayMode.ALWAYS_SHOW -> stringResource(id = R.string.settings_always_show_media)
     }
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/drive/FileProperty.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/drive/FileProperty.kt
@@ -2,7 +2,6 @@ package net.pantasystem.milktea.model.drive
 
 import kotlinx.datetime.Instant
 import net.pantasystem.milktea.model.user.User
-
 import java.io.Serializable as JSerializable
 
 data class FileProperty(
@@ -21,6 +20,8 @@ data class FileProperty(
     val url: String,
     val thumbnailUrl: String? = null,
 ) : JSerializable {
+    companion object;
+
     data class Id(
         val accountId: Long,
         val fileId: String,
@@ -75,4 +76,38 @@ data class FileProperty(
             },
         )
     }
+}
+
+fun FileProperty.Companion.make(
+    id: FileProperty.Id = FileProperty.Id(0L, ""),
+    name: String = "",
+    createdAt: Instant? = null,
+    type: String = "",
+    md5: String? = null,
+    size: Int? = null,
+    userId: User.Id? = null,
+    folderId: String? = null,
+    comment: String? = null,
+    properties: FileProperty.Properties? = null,
+    isSensitive: Boolean = false,
+    blurhash: String? = null,
+    url: String = "",
+    thumbnailUrl: String? = null,
+): FileProperty {
+    return FileProperty(
+        id = id,
+        name = name,
+        createdAt = createdAt,
+        type = type,
+        md5 = md5,
+        size = size,
+        userId = userId,
+        folderId = folderId,
+        comment = comment,
+        properties = properties,
+        isSensitive = isSensitive,
+        blurhash = blurhash,
+        url = url,
+        thumbnailUrl = thumbnailUrl,
+    )
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
@@ -174,4 +174,5 @@ enum class MediaDisplayMode(val value: Int) {
     AUTO(0),
     ALWAYS_HIDE(1),
     ALWAYS_HIDE_WHEN_MOBILE_NETWORK(2),
+    ALWAYS_SHOW(3),
 }


### PR DESCRIPTION
## やったこと
タイムライン上の投稿のサムネイルの表示状態のオプションに
常にメディアを表示する選択肢を追加しました。
またその設定状態に応じて表示状態の仕分けを行うようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1965 


