### PR TITLE
センシティブなメディアを含む投稿をタイムラインから除外できるようにした

### DIFF
--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -638,6 +638,7 @@
 
     <string name="settings_user_cache">ユーザキャッシュ</string>
     <string name="jump_to_new_post">新着投稿を表示</string>
+    <string name="exclude_if_exists_sensitive_media">Exclude if exists sensitive media</string>
 
 
 </resources>

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -630,15 +630,15 @@
     <string name="notification_sync_download_custom_emoji_title">カスタム絵文字ダウンロード中</string>
     <string name="alarm_permission_description_title">アラームの権限を付与してください</string>
     <string name="alarm_permission_description_message">予約投稿はアラーム機能の仕組みを利用するため、設定からMilkteaにアラームの権限を付与する必要性があります。</string>
-    <string name="exclude_replies">Exclude replies</string>
-    <string name="exclude_reposts">Exclude reposts</string>
+    <string name="exclude_replies">リプライを除外</string>
+    <string name="exclude_reposts">リポストを除外</string>
     <string name="notify_about_new_posts">投稿の通知を受信する</string>
     <string name="stop_notify_about_new_posts">投稿の通知をやめる</string>
     <!-- User -->
 
     <string name="settings_user_cache">ユーザキャッシュ</string>
     <string name="jump_to_new_post">新着投稿を表示</string>
-    <string name="exclude_if_exists_sensitive_media">Exclude if exists sensitive media</string>
+    <string name="exclude_if_exists_sensitive_media">センシティブなメディアを含む投稿を除外</string>
 
 
 </resources>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -628,6 +628,7 @@
     <!-- User -->
     <string name="settings_user_cache">User caches</string>
     <string name="jump_to_new_post">Jump to new post</string>
+    <string name="exclude_if_exists_sensitive_media">Exclude if exists senstive media</string>
 
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -635,6 +635,7 @@
     <string name="stop_notify_about_new_posts">Stop notify about new posts</string>
     <string name="settings_user_cache">User cache</string>
     <string name="jump_to_new_post">Jump to new post</string>
+    <string name="exclude_if_exists_sensitive_media">Exclude if exists sensitive media</string>
     <!-- reaction-acceptance -->
 
 </resources>

--- a/modules/data/schemas/net.pantasystem.milktea.data.infrastructure.DataBase/59.json
+++ b/modules/data/schemas/net.pantasystem.milktea.data.infrastructure.DataBase/59.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 58,
+    "version": 59,
     "identityHash": "9257b02f1c5fb08f3a6b602d66676be8",
     "entities": [
       {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/DataBase.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/DataBase.kt
@@ -133,7 +133,7 @@ import net.pantasystem.milktea.data.infrastructure.user.renote.mute.db.RenoteMut
         CustomEmojiRecord::class,
         CustomEmojiAliasRecord::class,
     ],
-    version = 58,
+    version = 59,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 11, to = 12),
@@ -181,6 +181,7 @@ import net.pantasystem.milktea.data.infrastructure.user.renote.mute.db.RenoteMut
         AutoMigration(from = 54, to = 55),
         AutoMigration(from = 55, to = 56),
         AutoMigration(from = 56, to = 57),
+        AutoMigration(from = 58, to = 59),
     ],
     views = [UserView::class, GroupMemberView::class, UserListMemberView::class]
 )

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/account/page/db/PageRecordParams.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/account/page/db/PageRecordParams.kt
@@ -79,6 +79,9 @@ data class PageRecordParams(
 
     @ColumnInfo(name = "excludeReposts")
     val excludeReposts: Boolean? = null,
+
+    @ColumnInfo(name = "excludeIfExistsSensitiveMedia")
+    val excludeIfExistsSensitiveMedia: Boolean? = null,
 ) {
     fun toParams(): PageParams {
         return PageParams(
@@ -107,6 +110,7 @@ data class PageRecordParams(
             clipId = clipId,
             excludeReplies = excludeReplies,
             excludeReposts = excludeReposts,
+            excludeIfExistsSensitiveMedia = excludeIfExistsSensitiveMedia,
         )
     }
 
@@ -139,6 +143,7 @@ data class PageRecordParams(
                     clipId = clipId,
                     excludeReplies = excludeReplies,
                     excludeReposts = excludeReposts,
+                    excludeIfExistsSensitiveMedia = excludeIfExistsSensitiveMedia,
                 )
             }
         }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -21,6 +21,7 @@ import net.pantasystem.milktea.model.note.Note
 import net.pantasystem.milktea.model.note.NoteStreaming
 import net.pantasystem.milktea.model.note.TimelineScrollPositionRepository
 import net.pantasystem.milktea.model.setting.LocalConfigRepository
+import net.pantasystem.milktea.note.timeline.viewmodel.filter.ExcludeIfExistsSensitiveMediaFilter
 import net.pantasystem.milktea.note.timeline.viewmodel.filter.ExcludeRepostOrReplyFilter
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewDataCache
@@ -163,6 +164,7 @@ class TimelineViewModel @AssistedInject constructor(
             }
         })
         cache.addFilter(ExcludeRepostOrReplyFilter(pageable))
+        cache.addFilter(ExcludeIfExistsSensitiveMediaFilter(pageable))
 
         timelineStore.setActiveStreamingChangedListener { isActiveStreaming ->
             if (isActiveStreaming && isActive) {

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/filter/ExcludeIfExistsSensitiveMediaFilter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/filter/ExcludeIfExistsSensitiveMediaFilter.kt
@@ -1,0 +1,36 @@
+package net.pantasystem.milktea.note.timeline.viewmodel.filter
+
+import net.pantasystem.milktea.model.account.page.CanExcludeIfExistsSensitiveMedia
+import net.pantasystem.milktea.model.account.page.Pageable
+import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
+import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewDataCache
+
+class ExcludeIfExistsSensitiveMediaFilter(private val pageable: Pageable) : PlaneNoteViewDataCache.ViewDataFilter {
+
+    override suspend fun check(viewData: PlaneNoteViewData): PlaneNoteViewData.FilterResult {
+        // 除外設定がされていない場合は何もしない
+        if ((pageable as? CanExcludeIfExistsSensitiveMedia<*>)?.getExcludeIfExistsSensitiveMedia() != true) {
+            return viewData.filterResult
+        }
+
+        // 自分の投稿ではないことを確認(リノートや返信も含む)
+        if (viewData.note.user.id.id == viewData.account.remoteId) {
+            // 何もしない
+            return viewData.filterResult
+        }
+
+        val hasSensitive = viewData.toShowNote.files?.any { file ->
+            file.isSensitive
+        } ?: false
+
+        val hasSensitiveInRenoteToNote = viewData.toShowNote.files?.any { file ->
+            file.isSensitive
+        } ?: false
+
+        if (hasSensitive || hasSensitiveInRenoteToNote) {
+            return PlaneNoteViewData.FilterResult.ShouldFilterNote
+        }
+
+        return viewData.filterResult
+    }
+}

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/EditTabSettingDialog.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/EditTabSettingDialog.kt
@@ -8,6 +8,7 @@ import androidx.core.view.isVisible
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.activityViewModels
 import dagger.hilt.android.AndroidEntryPoint
+import net.pantasystem.milktea.model.account.page.CanExcludeIfExistsSensitiveMedia
 import net.pantasystem.milktea.model.account.page.CanExcludeReplies
 import net.pantasystem.milktea.model.account.page.CanExcludeReposts
 import net.pantasystem.milktea.model.account.page.CanOnlyMedia
@@ -80,6 +81,13 @@ class EditTabSettingDialog : AppCompatDialogFragment(){
             binding.toggleExcludeReplies.isVisible = false
         }
 
+        if (page.pageable() is CanExcludeIfExistsSensitiveMedia<*>) {
+            binding.toggleExcludeIfExistsSensitiveMedia.isVisible = true
+            binding.toggleExcludeIfExistsSensitiveMedia.isChecked = page.pageParams.excludeIfExistsSensitiveMedia ?: false
+        } else {
+            binding.toggleExcludeIfExistsSensitiveMedia.isVisible = false
+        }
+
         binding.okButton.setOnClickListener {
             val name = binding.editTabName.text?.toString()
             if(name?.isNotBlank() == true){
@@ -107,6 +115,14 @@ class EditTabSettingDialog : AppCompatDialogFragment(){
                     is CanExcludeReposts<*> -> {
                         target = target.copy(
                             pageParams = (pageable.setExcludeReposts(binding.toggleExcludeReposts.isChecked) as Pageable).toParams()
+                        )
+                    }
+                    else -> Unit
+                }
+                when(val pageable = target.pageable()) {
+                    is CanExcludeIfExistsSensitiveMedia<*> -> {
+                        target = target.copy(
+                            pageParams = (pageable.setExcludeIfExistsSensitiveMedia(binding.toggleExcludeIfExistsSensitiveMedia.isChecked) as Pageable).toParams()
                         )
                     }
                     else -> Unit

--- a/modules/features/setting/src/main/res/layout/dialog_edit_tab_name.xml
+++ b/modules/features/setting/src/main/res/layout/dialog_edit_tab_name.xml
@@ -44,12 +44,19 @@
             android:layout_below="@id/toggleExcludeReplies"
             android:text="@string/exclude_reposts"/>
 
+        <com.google.android.material.switchmaterial.SwitchMaterial
+            android:id="@+id/toggleExcludeIfExistsSensitiveMedia"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/toggleExcludeReposts"
+            android:text="@string/exclude_if_exists_sensitive_media"/>
+
         <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/tabNameInput"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="8dp"
-                android:layout_below="@id/toggleExcludeReposts"
+                android:layout_below="@id/toggleExcludeIfExistsSensitiveMedia"
                 >
             <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/editTabName"

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageParams.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageParams.kt
@@ -33,6 +33,7 @@ data class PageParams(
     val clipId: String? = null,
     val excludeReplies: Boolean? = null,
     val excludeReposts: Boolean? = null,
+    val excludeIfExistsSensitiveMedia: Boolean? = null,
 ) : Serializable, Parcelable {
 
 
@@ -49,6 +50,7 @@ data class PageParams(
                         includeRenotedMyRenotes = includeRenotedMyRenotes,
                         excludeReposts = excludeReposts,
                         excludeReplies = excludeReplies,
+                        excludeIfExistsSensitiveMedia = excludeIfExistsSensitiveMedia,
                     )
                 }
                 LOCAL -> {
@@ -57,6 +59,7 @@ data class PageParams(
                         excludeNsfw = excludeNsfw,
                         excludeReplies = excludeReplies,
                         excludeReposts = excludeReposts,
+                        excludeIfExistsSensitiveMedia = excludeIfExistsSensitiveMedia,
                     )
                 }
                 SOCIAL -> {
@@ -64,7 +67,8 @@ data class PageParams(
                         withFiles = withFiles,
                         includeRenotedMyRenotes = includeRenotedMyRenotes,
                         includeMyRenotes = includeMyRenotes,
-                        includeLocalRenotes = includeLocalRenotes
+                        includeLocalRenotes = includeLocalRenotes,
+                        excludeIfExistsSensitiveMedia = excludeIfExistsSensitiveMedia,
                     )
                 }
                 GLOBAL -> {
@@ -72,6 +76,7 @@ data class PageParams(
                         withFiles = withFiles,
                         excludeReposts = excludeReposts,
                         excludeReplies = excludeReplies,
+                        excludeIfExistsSensitiveMedia = excludeIfExistsSensitiveMedia,
                     )
                 }
                 SEARCH -> {
@@ -162,6 +167,7 @@ data class PageParams(
                         isOnlyMedia = withFiles,
                         excludeReposts = excludeReposts,
                         excludeReplies = excludeReplies,
+                        excludeIfExistsSensitiveMedia = excludeIfExistsSensitiveMedia,
                     )
                 }
                 MASTODON_PUBLIC_TIMELINE -> {
@@ -169,12 +175,14 @@ data class PageParams(
                         isOnlyMedia = withFiles,
                         excludeReposts = excludeReposts,
                         excludeReplies = excludeReplies,
+                        excludeIfExistsSensitiveMedia = excludeIfExistsSensitiveMedia,
                     )
                 }
                 MASTODON_HOME_TIMELINE -> {
                     Pageable.Mastodon.HomeTimeline(
                         excludeReposts = excludeReposts,
                         excludeReplies = excludeReplies,
+                        excludeIfExistsSensitiveMedia = excludeIfExistsSensitiveMedia,
                     )
                 }
                 MASTODON_LIST_TIMELINE -> {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/Pageable.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/Pageable.kt
@@ -11,17 +11,20 @@ sealed class Pageable : Serializable {
 
         var withFiles: Boolean? = null,
         var excludeReposts: Boolean? = null,
-        var excludeReplies: Boolean? = null
+        var excludeReplies: Boolean? = null,
+        val excludeIfExistsSensitiveMedia: Boolean? = null
     ) : Pageable(), UntilPaginate, SincePaginate,
         CanOnlyMedia<GlobalTimeline>,
         CanExcludeReplies<GlobalTimeline>,
-        CanExcludeReposts<GlobalTimeline> {
+        CanExcludeReposts<GlobalTimeline>,
+        CanExcludeIfExistsSensitiveMedia<GlobalTimeline> {
         override fun toParams(): PageParams {
             return PageParams(
                 withFiles = withFiles,
                 type = PageType.GLOBAL,
                 excludeReplies = excludeReplies,
-                excludeReposts = excludeReposts
+                excludeReposts = excludeReposts,
+                excludeIfExistsSensitiveMedia = excludeIfExistsSensitiveMedia,
             )
         }
 
@@ -58,6 +61,16 @@ sealed class Pageable : Serializable {
                 excludeReposts = isExcludeReposts
             )
         }
+
+        override fun getExcludeIfExistsSensitiveMedia(): Boolean {
+            return excludeIfExistsSensitiveMedia ?: false
+        }
+
+        override fun setExcludeIfExistsSensitiveMedia(isExcludeIfExistsSensitiveMedia: Boolean): GlobalTimeline {
+            return copy(
+                excludeIfExistsSensitiveMedia = isExcludeIfExistsSensitiveMedia
+            )
+        }
     }
 
     data class LocalTimeline(
@@ -65,10 +78,11 @@ sealed class Pageable : Serializable {
         var withFiles: Boolean? = null,
         var excludeNsfw: Boolean? = null,
         var excludeReplies: Boolean? = null,
-        var excludeReposts: Boolean? = null
+        var excludeReposts: Boolean? = null,
+        var excludeIfExistsSensitiveMedia: Boolean? = null
 
     ) : Pageable(), UntilPaginate, SincePaginate, CanOnlyMedia<LocalTimeline>,
-        CanExcludeReplies<LocalTimeline>, CanExcludeReposts<LocalTimeline> {
+        CanExcludeReplies<LocalTimeline>, CanExcludeReposts<LocalTimeline>, CanExcludeIfExistsSensitiveMedia<LocalTimeline> {
         override fun toParams(): PageParams {
             return PageParams(
                 PageType.LOCAL,
@@ -110,6 +124,16 @@ sealed class Pageable : Serializable {
         override fun getExcludeReposts(): Boolean {
             return excludeReposts ?: false
         }
+
+        override fun setExcludeIfExistsSensitiveMedia(isExcludeIfExistsSensitiveMedia: Boolean): LocalTimeline {
+            return copy(
+                excludeIfExistsSensitiveMedia = isExcludeIfExistsSensitiveMedia
+            )
+        }
+
+        override fun getExcludeIfExistsSensitiveMedia(): Boolean {
+            return excludeIfExistsSensitiveMedia ?: false
+        }
     }
 
     data class HybridTimeline(
@@ -119,10 +143,11 @@ sealed class Pageable : Serializable {
         var includeMyRenotes: Boolean? = null,
         var includeRenotedMyRenotes: Boolean? = null,
         var excludeReplies: Boolean? = null,
-        var excludeReposts: Boolean? = null
+        var excludeReposts: Boolean? = null,
+        var excludeIfExistsSensitiveMedia: Boolean? = null
 
     ) : Pageable(), UntilPaginate, SincePaginate, CanOnlyMedia<HybridTimeline>,
-        CanExcludeReplies<HybridTimeline>, CanExcludeReposts<HybridTimeline> {
+        CanExcludeReplies<HybridTimeline>, CanExcludeReposts<HybridTimeline>, CanExcludeIfExistsSensitiveMedia<HybridTimeline> {
         override fun toParams(): PageParams {
             return PageParams(
                 type = PageType.SOCIAL,
@@ -131,7 +156,8 @@ sealed class Pageable : Serializable {
                 includeMyRenotes = includeMyRenotes,
                 includeRenotedMyRenotes = includeRenotedMyRenotes,
                 excludeReplies = excludeReplies,
-                excludeReposts = excludeReposts
+                excludeReposts = excludeReposts,
+                excludeIfExistsSensitiveMedia = excludeIfExistsSensitiveMedia,
             )
         }
 
@@ -166,6 +192,16 @@ sealed class Pageable : Serializable {
         override fun getExcludeReposts(): Boolean {
             return excludeReposts ?: false
         }
+
+        override fun getExcludeIfExistsSensitiveMedia(): Boolean {
+            return excludeIfExistsSensitiveMedia ?: false
+        }
+
+        override fun setExcludeIfExistsSensitiveMedia(isExcludeIfExistsSensitiveMedia: Boolean): HybridTimeline {
+            return copy(
+                excludeIfExistsSensitiveMedia = isExcludeIfExistsSensitiveMedia
+            )
+        }
     }
 
     data class HomeTimeline(
@@ -175,7 +211,8 @@ sealed class Pageable : Serializable {
         var includeMyRenotes: Boolean? = null,
         var includeRenotedMyRenotes: Boolean? = null,
         var excludeReplies: Boolean? = null,
-        var excludeReposts: Boolean? = null
+        var excludeReposts: Boolean? = null,
+        var excludeIfExistsSensitiveMedia: Boolean? = null
 
     ) : Pageable(), UntilPaginate, SincePaginate, CanOnlyMedia<HomeTimeline>,
         CanExcludeReplies<HomeTimeline>, CanExcludeReposts<HomeTimeline> {
@@ -189,6 +226,7 @@ sealed class Pageable : Serializable {
                 includeMyRenotes = includeMyRenotes,
                 excludeReplies = excludeReplies,
                 excludeReposts = excludeReposts,
+                excludeIfExistsSensitiveMedia = excludeIfExistsSensitiveMedia,
             )
         }
 
@@ -231,9 +269,9 @@ sealed class Pageable : Serializable {
         var withFiles: Boolean? = null,
         var includeLocalRenotes: Boolean? = null,
         var includeMyRenotes: Boolean? = null,
-        var includeRenotedMyRenotes: Boolean? = null
-
-    ) : Pageable(), UntilPaginate, SincePaginate, CanOnlyMedia<UserListTimeline> {
+        var includeRenotedMyRenotes: Boolean? = null,
+        var excludeIfExistsSensitiveMedia: Boolean? = null,
+    ) : Pageable(), UntilPaginate, SincePaginate, CanOnlyMedia<UserListTimeline>, CanExcludeIfExistsSensitiveMedia<UserListTimeline> {
 
         override fun toParams(): PageParams {
             return PageParams(
@@ -242,7 +280,8 @@ sealed class Pageable : Serializable {
                 withFiles = withFiles,
                 includeLocalRenotes = includeLocalRenotes,
                 includeMyRenotes = includeMyRenotes,
-                includeRenotedMyRenotes = includeRenotedMyRenotes
+                includeRenotedMyRenotes = includeRenotedMyRenotes,
+                excludeIfExistsSensitiveMedia = excludeIfExistsSensitiveMedia,
             )
         }
 
@@ -256,6 +295,16 @@ sealed class Pageable : Serializable {
 
         override fun getOnlyMedia(): Boolean {
             return withFiles ?: false
+        }
+
+        override fun getExcludeIfExistsSensitiveMedia(): Boolean {
+            return excludeIfExistsSensitiveMedia ?: false
+        }
+
+        override fun setExcludeIfExistsSensitiveMedia(isExcludeIfExistsSensitiveMedia: Boolean): UserListTimeline {
+            return copy(
+                excludeIfExistsSensitiveMedia = isExcludeIfExistsSensitiveMedia
+            )
         }
     }
 
@@ -479,13 +528,15 @@ sealed class Pageable : Serializable {
             val isOnlyMedia: Boolean? = null,
             val excludeReplies: Boolean? = null,
             val excludeReposts: Boolean? = null,
-        ) : Mastodon(), CanOnlyMedia<PublicTimeline>, UntilPaginate, SincePaginate, CanExcludeReplies<PublicTimeline>, CanExcludeReposts<PublicTimeline> {
+            val excludeIfExistsSensitiveMedia: Boolean? = null,
+        ) : Mastodon(), CanOnlyMedia<PublicTimeline>, UntilPaginate, SincePaginate, CanExcludeReplies<PublicTimeline>, CanExcludeReposts<PublicTimeline>, CanExcludeIfExistsSensitiveMedia<PublicTimeline> {
             override fun toParams(): PageParams {
                 return PageParams(
                     type = PageType.MASTODON_PUBLIC_TIMELINE,
                     withFiles = isOnlyMedia,
                     excludeReplies = excludeReplies,
-                    excludeReposts = excludeReposts
+                    excludeReposts = excludeReposts,
+                    excludeIfExistsSensitiveMedia = excludeIfExistsSensitiveMedia,
                 )
             }
 
@@ -518,13 +569,24 @@ sealed class Pageable : Serializable {
             override fun getExcludeReposts(): Boolean {
                 return excludeReposts ?: false
             }
+
+            override fun getExcludeIfExistsSensitiveMedia(): Boolean {
+                return excludeIfExistsSensitiveMedia ?: false
+            }
+
+            override fun setExcludeIfExistsSensitiveMedia(isExcludeIfExistsSensitiveMedia: Boolean): PublicTimeline {
+                return copy(
+                    excludeIfExistsSensitiveMedia = isExcludeIfExistsSensitiveMedia
+                )
+            }
         }
 
         data class LocalTimeline(
             val isOnlyMedia: Boolean? = null,
             val excludeReplies: Boolean? = null,
             val excludeReposts: Boolean? = null,
-        ) : Mastodon(), CanOnlyMedia<LocalTimeline>, UntilPaginate, SincePaginate, CanExcludeReplies<LocalTimeline>, CanExcludeReposts<LocalTimeline> {
+            val excludeIfExistsSensitiveMedia: Boolean? = null,
+        ) : Mastodon(), CanOnlyMedia<LocalTimeline>, UntilPaginate, SincePaginate, CanExcludeReplies<LocalTimeline>, CanExcludeReposts<LocalTimeline>, CanExcludeIfExistsSensitiveMedia<LocalTimeline> {
             override fun toParams(): PageParams {
                 return PageParams(
                     type = PageType.MASTODON_LOCAL_TIMELINE,
@@ -563,6 +625,16 @@ sealed class Pageable : Serializable {
             override fun getExcludeReposts(): Boolean {
                 return excludeReposts ?: false
             }
+
+            override fun getExcludeIfExistsSensitiveMedia(): Boolean {
+                return excludeIfExistsSensitiveMedia ?: false
+            }
+
+            override fun setExcludeIfExistsSensitiveMedia(isExcludeIfExistsSensitiveMedia: Boolean): LocalTimeline {
+                return copy(
+                    excludeIfExistsSensitiveMedia = isExcludeIfExistsSensitiveMedia
+                )
+            }
         }
 
         data class HashTagTimeline(val hashtag: String, val isOnlyMedia: Boolean? = null) :
@@ -598,7 +670,8 @@ sealed class Pageable : Serializable {
         data class HomeTimeline(
             val excludeReplies: Boolean? = null,
             val excludeReposts: Boolean? = null,
-        ) : Mastodon(), SincePaginate, UntilPaginate, CanExcludeReposts<HomeTimeline>, CanExcludeReplies<HomeTimeline> {
+            val excludeIfExistsSensitiveMedia: Boolean? = null,
+        ) : Mastodon(), SincePaginate, UntilPaginate, CanExcludeReposts<HomeTimeline>, CanExcludeReplies<HomeTimeline>, CanExcludeIfExistsSensitiveMedia<HomeTimeline> {
             override fun toParams(): PageParams {
                 return PageParams(
                     type = PageType.MASTODON_HOME_TIMELINE,
@@ -624,6 +697,16 @@ sealed class Pageable : Serializable {
             override fun setExcludeReposts(isExcludeReposts: Boolean): HomeTimeline {
                 return copy(
                     excludeReposts = isExcludeReposts
+                )
+            }
+
+            override fun getExcludeIfExistsSensitiveMedia(): Boolean {
+                return excludeIfExistsSensitiveMedia ?: false
+            }
+
+            override fun setExcludeIfExistsSensitiveMedia(isExcludeIfExistsSensitiveMedia: Boolean): HomeTimeline {
+                return copy(
+                    excludeIfExistsSensitiveMedia = isExcludeIfExistsSensitiveMedia
                 )
             }
         }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/Pageable.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/Pageable.kt
@@ -719,3 +719,8 @@ interface CanExcludeReposts<T> {
     fun setExcludeReposts(isExcludeReposts: Boolean): T
     fun getExcludeReposts(): Boolean
 }
+
+interface CanExcludeIfExistsSensitiveMedia<T> {
+    fun setExcludeIfExistsSensitiveMedia(isExcludeIfExistsSensitiveMedia: Boolean): T
+    fun getExcludeIfExistsSensitiveMedia(): Boolean
+}


### PR DESCRIPTION
## やったこと
タイムラインからセンシティブな投稿を除外するオプションを追加しました。
タブの設定画面から設定できるようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
#1962 

