### PR TITLE
feat: ユーザが誕生日の時にプロフィール画面で紙吹雪を降らせる

### DIFF
--- a/modules/features/user/build.gradle
+++ b/modules/features/user/build.gradle
@@ -123,4 +123,5 @@ dependencies {
 
     implementation 'com.github.kenglxn.QRGen:android:3.0.1'
 
+    implementation libs.konfetti
 }

--- a/modules/features/user/src/main/res/layout/activity_user_detail.xml
+++ b/modules/features/user/src/main/res/layout/activity_user_detail.xml
@@ -34,6 +34,15 @@
                         app:mainNameView="@{mainName}"
                         app:subNameView="@{subName}"
                         >
+                    <nl.dionsegijn.konfetti.xml.KonfettiView
+                        android:id="@+id/konfettiView"
+                        android:layout_width="0px"
+                        android:layout_height="0px"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintLeft_toLeftOf="parent"
+                        app:layout_constraintRight_toRightOf="parent"
+                        />
                     <LinearLayout
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"

--- a/settings.gradle
+++ b/settings.gradle
@@ -102,6 +102,8 @@ dependencyResolutionManagement {
             library("recyclerview", "androidx.recyclerview:recyclerview:1.3.1")
 
             library("objectbox-kotlin", "io.objectbox:objectbox-kotlin:3.5.1")
+
+            library("konfetti", "nl.dionsegijn:konfetti-xml:2.0.3")
         }
     }
 }


### PR DESCRIPTION
## やったこと
ユーザが誕生日の時にプロフィール画面を開くと紙吹雪を降らせるようにした

## 動作確認
[Screen_recording_20231124_213658.webm](https://github.com/pantasystem/Milktea/assets/62137820/e328aadc-7f03-402a-ba43-e7403a49c789)


## 備考
- デフォルトだと紙吹雪がヘッダーやアイコンの後ろを通ってしまうので`bringToFront()`を使って前面に出しています

## 懸念事項
メモリがリークしている？
```
net.pantasystem.milktea.user.profile.UserDetailActivity instance
2023-11-24 21:27:50.698  9047-10008 LeakCanary              jp.panta.misskeyandroidclient        D  ​  Leaking: YES (ObjectWatcher was watching this because net.pantasystem.milktea.user.profile.UserDetailActivity
2023-11-24 21:27:50.698  9047-10008 LeakCanary              jp.panta.misskeyandroidclient        D  ​  received Activity#onDestroy() callback and Activity#mDestroyed is true)
2023-11-24 21:27:50.698  9047-10008 LeakCanary              jp.panta.misskeyandroidclient        D  ​  key = d0dc81ac-c36e-499e-b77b-554748aa38de
2023-11-24 21:27:50.698  9047-10008 LeakCanary              jp.panta.misskeyandroidclient        D  ​  watchDurationMillis = 5658
2023-11-24 21:27:50.698  9047-10008 LeakCanary              jp.panta.misskeyandroidclient        D  ​  retainedDurationMillis = 656
2023-11-24 21:27:50.698  9047-10008 LeakCanary              jp.panta.misskeyandroidclient        D  ​  mApplication instance of jp.panta.misskeyandroidclient.MiApplication
2023-11-24 21:27:50.698  9047-10008 LeakCanary              jp.panta.misskeyandroidclient        D  ​  mBase instance of androidx.appcompat.view.ContextThemeWrapper
```
Coroutineの部分の書き方が良くない可能性が高いです
## Issue番号
Fixed #1957


