### PR TITLE
新規投稿受信時の感覚フィードバックを設定から切り替えられるようにした

### DIFF
--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -651,4 +651,6 @@
     <string name="confirm_display_sensitive_media_dialog_positive_button">表示</string>
     <string name="confirm_display_sensitive_media_dialog_neutral_button">警告を非表示</string>
 
+    <string name="settings_enable_haptic_feedback_on_new_post">新帖子的触觉反馈</string>
+
 </resources>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -640,4 +640,5 @@
     <string name="confirm_display_sensitive_media_dialog_positive_button">显示</string>
     <string name="confirm_display_sensitive_media_dialog_neutral_button">不要警告</string>
 
+    <string name="settings_enable_haptic_feedback_on_new_post">Enable haptic feedback on new post</string>
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -648,4 +648,6 @@
     <string name="confirm_display_sensitive_media_dialog_neutral_button">Do not warn</string>
     <!-- reaction-acceptance -->
 
+    <string name="settings_enable_haptic_feedback_on_new_post">Enable haptic feedback on new post</string>
+
 </resources>

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Config.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Config.kt
@@ -164,6 +164,9 @@ fun Config.Companion.from(map: Map<Keys, PrefType?>): Config {
         isShowWarningDisplayingSensitiveMedia = map.getValue<PrefType.BoolPref>(
             Keys.IsShowWarningDisplayingSensitiveMedia
         )?.value ?: DefaultConfig.config.isShowWarningDisplayingSensitiveMedia,
+        isEnableHapticFeedbackOnNewPost = map.getValue<PrefType.BoolPref>(
+            Keys.IsEnableHapticFeedbackOnNewPost
+        )?.value ?: DefaultConfig.config.isEnableHapticFeedbackOnNewPost,
     )
 }
 
@@ -321,6 +324,9 @@ fun Config.pref(key: Keys): PrefType {
         }
         Keys.IsShowWarningDisplayingSensitiveMedia -> {
             PrefType.BoolPref(isShowWarningDisplayingSensitiveMedia)
+        }
+        Keys.IsEnableHapticFeedbackOnNewPost -> {
+            PrefType.BoolPref(isEnableHapticFeedbackOnNewPost)
         }
     }
 }

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/ConfigKtTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/ConfigKtTest.kt
@@ -185,6 +185,10 @@ class ConfigKtTest {
                     config.isShowWarningDisplayingSensitiveMedia,
                     (u as PrefType.BoolPref).value
                 )
+                Keys.IsEnableHapticFeedbackOnNewPost -> Assertions.assertEquals(
+                    config.isEnableHapticFeedbackOnNewPost,
+                    (u as PrefType.BoolPref).value
+                )
             }
         }
     }

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/KeysKtTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/KeysKtTest.kt
@@ -145,6 +145,10 @@ class KeysKtTest {
                     "IsShowWarningDisplayingSensitiveMedia",
                     key.str()
                 )
+                Keys.IsEnableHapticFeedbackOnNewPost -> Assertions.assertEquals(
+                    "IsEnableHapticFeedbackOnNewPost",
+                    key.str()
+                )
             }
         }
     }
@@ -152,8 +156,8 @@ class KeysKtTest {
 
     @Test
     fun checkAllKeysCount() {
-        Assertions.assertEquals(37, Keys.allKeys.size)
-        Assertions.assertEquals(37, Keys.allKeys.map { it.str() }.toSet().size)
+        Assertions.assertEquals(38, Keys.allKeys.size)
+        Assertions.assertEquals(38, Keys.allKeys.map { it.str() }.toSet().size)
     }
 
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
@@ -33,6 +33,7 @@ import net.pantasystem.milktea.common_viewmodel.CurrentPageableTimelineViewModel
 import net.pantasystem.milktea.common_viewmodel.ScrollToTopViewModel
 import net.pantasystem.milktea.model.account.page.Page
 import net.pantasystem.milktea.model.account.page.Pageable
+import net.pantasystem.milktea.model.setting.DefaultConfig
 import net.pantasystem.milktea.model.setting.LocalConfigRepository
 import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.databinding.FragmentTimelineBinding
@@ -353,6 +354,8 @@ class TimelineFragment : Fragment(R.layout.fragment_timeline), PageableView {
     }
 
     private fun performNewPostReceivedVibrateFeedback() {
-        HapticFeedbackController.performTickVibrateHapticFeedback(requireContext())
+        if (configRepository.get().getOrElse { DefaultConfig.config }.isEnableHapticFeedbackOnNewPost) {
+            HapticFeedbackController.performTickVibrateHapticFeedback(requireContext())
+        }
     }
 }

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingMovementActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingMovementActivity.kt
@@ -237,6 +237,15 @@ class SettingMovementActivity : AppCompatActivity() {
                                     Text(stringResource(id = R.string.is_stop_note_capture_when_background))
                                 }
                             }
+                            SettingSwitchTile(
+                                checked = currentConfigState.isEnableHapticFeedbackOnNewPost,
+                                onChanged = {
+                                    currentConfigState =
+                                        currentConfigState.copy(isEnableHapticFeedbackOnNewPost = it)
+                                }
+                            ) {
+                                Text(stringResource(id = R.string.settings_enable_haptic_feedback_on_new_post))
+                            }
                         }
                         SettingSection(title = stringResource(id = R.string.media)) {
                             Box(

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
@@ -95,6 +95,7 @@ data class Config(
     val mediaDisplayMode: MediaDisplayMode,
     val isEnableSafeSearch: IsSafeSearchEnabled,
     val isShowWarningDisplayingSensitiveMedia: Boolean,
+    val isEnableHapticFeedbackOnNewPost: Boolean,
 ) {
     companion object
 
@@ -164,6 +165,7 @@ object DefaultConfig {
             isConfirmed = false,
         ),
         isShowWarningDisplayingSensitiveMedia = true,
+        isEnableHapticFeedbackOnNewPost = true,
     )
 
     fun getRememberVisibilityConfig(accountId: Long): RememberVisibility.Remember {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Keys.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Keys.kt
@@ -39,6 +39,7 @@ val Keys.Companion.allKeys by lazy {
         Keys.IsSafeSearchEnabled,
         Keys.IsConfirmedSafeSearchEnabled,
         Keys.IsShowWarningDisplayingSensitiveMedia,
+        Keys.IsEnableHapticFeedbackOnNewPost,
     )
 }
 
@@ -112,6 +113,8 @@ sealed interface Keys {
 
     data object IsShowWarningDisplayingSensitiveMedia : Keys
 
+    data object IsEnableHapticFeedbackOnNewPost : Keys
+
     companion object
 }
 
@@ -154,5 +157,6 @@ fun Keys.str(): String {
         is Keys.IsSafeSearchEnabled -> "ExcludeIfExistsSensitiveMedia"
         is Keys.IsConfirmedSafeSearchEnabled -> "IsConfirmedSafeSearchEnabled"
         is Keys.IsShowWarningDisplayingSensitiveMedia -> "IsShowWarningDisplayingSensitiveMedia"
+        is Keys.IsEnableHapticFeedbackOnNewPost -> "IsEnableHapticFeedbackOnNewPost"
     }
 }


### PR DESCRIPTION
## やったこと
タイムラインでのストリーミング経由での新規投稿受信時の感覚フィードバックを
設定からON/OFFを切り替えられるようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1991 


