### PR TITLE
feat: CWで注釈を空欄のままノートできないようにする

### DIFF
--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorUiState.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorUiState.kt
@@ -58,8 +58,12 @@ data class NoteEditorUiState(
     val totalFilesCount: Int
         get() = this.files.size
 
-    fun checkValidate(textMaxLength: Int = 3000, maxFileCount: Int = 4): Boolean {
+    fun checkValidate(textMaxLength: Int = 3000, maxFileCount: Int = 4, isCwAllowBlank: Boolean = true): Boolean {
         if (this.files.size > maxFileCount) {
+            return false
+        }
+
+        if(!isCwAllowBlank) {
             return false
         }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorUiState.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorUiState.kt
@@ -63,7 +63,7 @@ data class NoteEditorUiState(
             return false
         }
 
-        if(!isCwAllowBlank) {
+        if (!isCwAllowBlank && formState.hasCw && formState.cw.isNullOrEmpty()) {
             return false
         }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
@@ -123,6 +123,10 @@ class NoteEditorViewModel @Inject constructor(
             initialValue = 3000
         )
 
+    private val isCwAllowBlank = instanceInfoType.map {
+        it?.isCwAllowBlank ?: true
+    }.stateIn(viewModelScope, started = SharingStarted.Eagerly, initialValue = true)
+
 
     val enableFeatures = _currentAccount.filterNotNull().map {
         featureEnables.enableFeatures(it.normalizedInstanceUri)
@@ -242,7 +246,7 @@ class NoteEditorViewModel @Inject constructor(
     }.stateIn(viewModelScope + Dispatchers.IO, started = SharingStarted.Lazily, initialValue = 1500)
 
     val isPostAvailable = uiState.map {
-        it.checkValidate(textMaxLength = maxTextLength.value, maxFileCount = maxFileCount.value)
+        it.checkValidate(textMaxLength = maxTextLength.value, maxFileCount = maxFileCount.value, isCwAllowBlank = isCwAllowBlank.value)
     }.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(5_000),

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
@@ -123,10 +123,6 @@ class NoteEditorViewModel @Inject constructor(
             initialValue = 3000
         )
 
-    private val isCwAllowBlank = instanceInfoType.map {
-        it?.isCwAllowBlank ?: true
-    }.stateIn(viewModelScope, started = SharingStarted.Eagerly, initialValue = true)
-
 
     val enableFeatures = _currentAccount.filterNotNull().map {
         featureEnables.enableFeatures(it.normalizedInstanceUri)
@@ -245,8 +241,9 @@ class NoteEditorViewModel @Inject constructor(
         logger.error("observe meta error", it)
     }.stateIn(viewModelScope + Dispatchers.IO, started = SharingStarted.Lazily, initialValue = 1500)
 
-    val isPostAvailable = uiState.map {
-        it.checkValidate(textMaxLength = maxTextLength.value, maxFileCount = maxFileCount.value, isCwAllowBlank = isCwAllowBlank.value)
+    val isPostAvailable = combine(instanceInfoType, uiState) { instanceInfo, uiState ->
+        val isCwAllowBlank = instanceInfo?.isCwAllowBlank ?: true
+        uiState.checkValidate(textMaxLength = maxTextLength.value, maxFileCount = maxFileCount.value, isCwAllowBlank = isCwAllowBlank)
     }.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(5_000),


### PR DESCRIPTION
## 概要
misskeyのバージョンが11.1以上の時、「内容を隠す」で注釈が空の時にノートできなくなった https://github.com/misskey-dev/misskey/issues/12217
上記条件を満たすサーバーにmilkteaでログインして注釈が空のままノートするとエラーが発生する

## やったこと
milkteaのバージョンが　"2023.11.0"　以上の時に注釈が空欄のままノートできないようにした
## 動作確認
https://github.com/pantasystem/Milktea/assets/62137820/5a78ed47-3d80-4f00-bd0c-a5fb9e09ebf2


## 懸念事項
- coroutineScopeに `Dispatchers.IO` を加えるべきかが分からない
    - とりあえず IO が絡んでないように見えるのでつけなかった
- 今回の `started` は自分の感覚では `WhileSubscribed` なのだが`Eagerly`にしないと値が取れなかった
    - CWのボタンを押して注釈欄が出てきたときのみアクティブになればよいと思ったのですが...
- そもそも新しく変数 `private val isCwAllowBlank` を作らなくても既存変数を使えばうまく実装できたかも？

## Issue番号

Fixed #1992

